### PR TITLE
Change treyresearch to approved fictitious domain

### DIFF
--- a/compliance/uk-official/three-tier-web-with-adds/parameters/azure/add-adds-domain-controller.parameters.json
+++ b/compliance/uk-official/three-tier-web-with-adds/parameters/azure/add-adds-domain-controller.parameters.json
@@ -19,7 +19,7 @@
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/reference-architectures/master/compliance/uk-official/three-tier-web-with-adds/templates/onpremise/adds-domain-controller-extension-settings-mapper.json",
               "settingsConfig": {
                 "activeDirectorySettings": {
-                  "domainName": "treyresearch.com",
+                  "domainName": "treyresearch.net",
                   "adminUser": "adminuser",
                   "adminPassword": "AweS0me@PW",
                   "siteName": "Default-First-Site-Name",

--- a/compliance/uk-official/three-tier-web-with-adds/parameters/azure/create-adds-forest-extension.parameters.json
+++ b/compliance/uk-official/three-tier-web-with-adds/parameters/azure/create-adds-forest-extension.parameters.json
@@ -19,7 +19,7 @@
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/reference-architectures/master/compliance/uk-official/three-tier-web-with-adds/templates/onpremise/adds-domain-controller-extension-settings-mapper.json",
               "settingsConfig": {
                 "activeDirectorySettings": {
-                  "domainName": "treyresearch.com",
+                  "domainName": "treyresearch.net",
                   "domainNetbiosName": "treyresearch",
                   "safeModePassword": "Saf3M0de@PW"
                 },

--- a/compliance/uk-official/three-tier-web-with-adds/parameters/azure/vm-domain-join.parameters.json
+++ b/compliance/uk-official/three-tier-web-with-adds/parameters/azure/vm-domain-join.parameters.json
@@ -18,9 +18,9 @@
               "autoUpgradeMinorVersion": true,
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/template-building-blocks/v1.0.0/templates/resources/Microsoft.Compute/virtualMachines/extensions/vm-extension-passthrough-settings-mapper.json",
               "settingsConfig": {
-                "Name": "treyresearch.com",
+                "Name": "treyresearch.net",
                 "OUPath": "",
-                "User": "treyresearch.com\\AdminUser",
+                "User": "treyresearch.net\\AdminUser",
                 "Restart": true,
                 "Options": 3
               },

--- a/compliance/uk-official/three-tier-web-with-adds/templates/aads.azuredeploy.json
+++ b/compliance/uk-official/three-tier-web-with-adds/templates/aads.azuredeploy.json
@@ -11,7 +11,7 @@
     },
     "domainName": {
       "type": "string",
-      "defaultValue": "treyresearch.com",
+      "defaultValue": "treyresearch.net",
       "metadata": {
         "description": "AD Domain"
       }

--- a/identity/adds-forest/extensions/incoming-trust.ps1
+++ b/identity/adds-forest/extensions/incoming-trust.ps1
@@ -3,7 +3,7 @@
 $TrustedDomainName = "contoso.com"
 #$TrustedDomainDnsIpAddresses = "192.168.0.4,192.168.0.5"
 
-$TrustingDomainName = "treyresearch.com"
+$TrustingDomainName = "treyresearch.net"
 $TrustingDomainDnsIpAddresses = "10.0.4.4,10.0.4.5"
 
 $ForwardIpAddress  = $TrustingDomainDnsIpAddresses

--- a/identity/adds-forest/extensions/outgoing-trust.ps1
+++ b/identity/adds-forest/extensions/outgoing-trust.ps1
@@ -6,7 +6,7 @@
 $TrustedDomainName = "contoso.com"
 $TrustedDomainDnsIpAddresses = "192.168.0.4,192.168.0.5"
 
-#$TrustingDomainName = "treyresearch.com"
+#$TrustingDomainName = "treyresearch.net"
 #$TrustingDomainDnsIpAddresses = "10.0.4.4,10.0.4.5"
 
 $ForwardIpAddress  = $TrustedDomainDnsIpAddresses

--- a/identity/adds-forest/parameters/azure/add-adds-domain-controller.parameters.json
+++ b/identity/adds-forest/parameters/azure/add-adds-domain-controller.parameters.json
@@ -15,9 +15,9 @@
               "autoUpgradeMinorVersion": true,
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/template-building-blocks/v1.0.0/templates/resources/Microsoft.Compute/virtualMachines/extensions/vm-extension-passthrough-settings-mapper.json",
               "settingsConfig": {
-                "Name": "treyresearch.com",
+                "Name": "treyresearch.net",
                 "OUPath": "",
-                "User": "treyresearch.com\\testuser",
+                "User": "treyresearch.net\\testuser",
                 "Restart": true,
                 "Options": 3
               },
@@ -34,7 +34,7 @@
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/reference-architectures/master/identity/adds-forest/templates/onpremise/adds-domain-controller-extension-settings-mapper.json",
               "settingsConfig": {
                 "activeDirectorySettings": {
-                  "domainName": "treyresearch.com",
+                  "domainName": "treyresearch.net",
                   "adminUser": "testuser",
                   "adminPassword": "AweS0me@PW",
                   "siteName": "Default-First-Site-Name",

--- a/identity/adds-forest/parameters/azure/create-adds-forest-extension.parameters.json
+++ b/identity/adds-forest/parameters/azure/create-adds-forest-extension.parameters.json
@@ -16,7 +16,7 @@
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/reference-architectures/master/identity/adds-forest/templates/onpremise/ad-forest-extension-settings-mapper.json",
               "settingsConfig": {
                 "activeDirectorySettings": {
-                  "domainName": "treyresearch.com",
+                  "domainName": "treyresearch.net",
                   "domainNetbiosName": "treyresearch",
                   "safeModePassword": "Saf3M0de@PW"
                 },

--- a/identity/adds-forest/parameters/azure/web-vm-domain-join.parameters.json
+++ b/identity/adds-forest/parameters/azure/web-vm-domain-join.parameters.json
@@ -15,9 +15,9 @@
               "autoUpgradeMinorVersion": true,
               "settingsConfigMapperUri": "https://raw.githubusercontent.com/mspnp/template-building-blocks/v1.0.0/templates/resources/Microsoft.Compute/virtualMachines/extensions/vm-extension-passthrough-settings-mapper.json",
               "settingsConfig": {
-                "Name": "treyresearch.com",
+                "Name": "treyresearch.net",
                 "OUPath": "",
-                "User": "treyresearch.com\\testuser",
+                "User": "treyresearch.net\\testuser",
                 "Restart": true,
                 "Options": 3
               },


### PR DESCRIPTION
treyresearch.com is not in our approved fictitious URL list, should be treyresearch.net