### PR TITLE
hub spoke fixes

### DIFF
--- a/hybrid-networking/hub-spoke/hub-vnet-peering.json
+++ b/hybrid-networking/hub-spoke/hub-vnet-peering.json
@@ -6,6 +6,7 @@
             "value": [
                 {
                     "type": "VirtualNetwork",
+                    "resourceGroupName": "hub-vnet-rg",
                     "settings": [
                         {
                             "name": "hub-vnet",

--- a/hybrid-networking/hub-spoke/hub-vnet.json
+++ b/hybrid-networking/hub-spoke/hub-vnet.json
@@ -70,7 +70,7 @@
                         {
                             "connectionType": "Vnet2Vnet",
                             "name": "hub-onprem-conn",
-                            "sharedKey": "sdfsdf6545654dfgdfgdf345435sdfgregruyiyi234",
+                            "sharedKey": "",
                             "routingWeight": 1,
                             "virtualNetworkGateway1": {
                                 "resourceGroupName": "onprem-vnet-rg",

--- a/hybrid-networking/hub-spoke/hub-vnet.json
+++ b/hybrid-networking/hub-spoke/hub-vnet.json
@@ -6,6 +6,7 @@
             "value": [
                 {
                     "type": "VirtualNetwork",
+                    "resourceGroupName": "hub-vnet-rg",
                     "settings": [
                         {
                             "name": "hub-vnet",
@@ -32,13 +33,13 @@
                 {
                     "type": "VirtualMachine",
                     "settings": {
-                        "resourceGroupName": "hub-jb-rg",
+                        "resourceGroupName": "hub-vnet-rg",
                         "vmCount": 1,
                         "namePrefix": "hubjb",
                         "computerNamePrefix": "hubjb",
                         "adminUsername": "",
                         "adminPassword": "",
-                        "osType": "",
+                        "osType": "windows",
                         "virtualNetwork": {
                             "name": "hub-vnet"
                         },
@@ -69,7 +70,7 @@
                         {
                             "connectionType": "Vnet2Vnet",
                             "name": "hub-onprem-conn",
-                            "sharedKey": "",
+                            "sharedKey": "sdfsdf6545654dfgdfgdf345435sdfgregruyiyi234",
                             "routingWeight": 1,
                             "virtualNetworkGateway1": {
                                 "resourceGroupName": "onprem-vnet-rg",

--- a/hybrid-networking/hub-spoke/onprem.json
+++ b/hybrid-networking/hub-spoke/onprem.json
@@ -35,7 +35,7 @@
                         "size": "Standard_DS1_v2",
                         "adminUsername": "",
                         "adminPassword": "",
-                        "osType": "",
+                        "osType": "windows",
                         "virtualNetwork": {
                             "resourceGroupName": "onprem-vnet-rg",
                             "name": "onprem-vnet"

--- a/hybrid-networking/hub-spoke/spoke1.json
+++ b/hybrid-networking/hub-spoke/spoke1.json
@@ -6,6 +6,7 @@
             "value": [           
                 {
                     "type": "VirtualNetwork",
+                    "resourceGroupName": "spoke1-vnet-rg",
                     "settings": [
                         {
                             "name": "spoke1-vnet",
@@ -40,13 +41,13 @@
                 {
                     "type": "VirtualMachine",
                     "settings": {
-                        "resourceGroupName": "spoke1-jb-rg",
+                        "resourceGroupName": "spoke1-vnet-rg",
                         "vmCount": 1,
                         "namePrefix": "s1jb",
                         "computerNamePrefix": "s1jb",
                         "adminUsername": "",
                         "adminPassword": "",
-                        "osType": "",
+                        "osType": "windows",
                         "virtualNetwork": {
                             "resourceGroupName": "spoke1-vnet-rg",
                             "name": "spoke1-vnet"

--- a/hybrid-networking/hub-spoke/spoke2.json
+++ b/hybrid-networking/hub-spoke/spoke2.json
@@ -6,6 +6,7 @@
             "value": [           
                 {
                     "type": "VirtualNetwork",
+                    "resourceGroupName": "spoke2-vnet-rg",
                     "settings": [
                         {
                             "name": "spoke2-vnet",
@@ -40,13 +41,13 @@
                 {
                     "type": "VirtualMachine",
                     "settings": {
-                        "resourceGroupName": "spoke2-jb-rg",
+                        "resourceGroupName": "spoke2-vnet-rg",
                         "vmCount": 1,
                         "namePrefix": "s2jb",
                         "computerNamePrefix": "s2jb",
                         "adminUsername": "",
                         "adminPassword": "",
-                        "osType": "",
+                        "osType": "windows",
                         "virtualNetwork": {
                             "resourceGroupName": "spoke2-vnet-rg",
                             "name": "spoke2-vnet"


### PR DESCRIPTION
onprem.json
    - missing osType

hub-vnet.json
    - specify vnet rg (hub-vnet-rg) because in other templates is hardcoded
    - vm cannot be in a diff rg, use "hub-vnet-rg"

spoke1.json
    - missing osType on vm
    - specify vm and vnet resource group "spoke1-vnet-rg" because in other templates is hardcoded

spoke2.json
    - missing osType on vm
    - specify vm and vnet resource group "spoke2-vnet-rg" because in other templates is hardcoded

hub-vnet-peering.json
    - specify vnet resource group "hub-vnet-rg"