### PR TITLE
Add gateway connection in the other direction

### DIFF
--- a/hybrid-networking/hub-spoke/hub-vnet.json
+++ b/hybrid-networking/hub-spoke/hub-vnet.json
@@ -82,6 +82,25 @@
                             }
                         }
                     ]
+                },
+                {
+                    "type": "Connection",
+                    "settings": [
+                        {
+                            "connectionType": "Vnet2Vnet",
+                            "name": "onprem-hub-conn",
+                            "sharedKey": "",
+                            "routingWeight": 1,
+                            "virtualNetworkGateway1": {
+                                "resourceGroupName": "hub-vnet-rg",
+                                "name": "hub-vpn-gateway1"
+                            },
+                            "virtualNetworkGateway2": {
+                                "resourceGroupName": "onprem-vnet-rg",
+                                "name": "onprem-vpn-gateway1"
+                            }
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
Deployment did not create the VPN gateway connection in both directions, so the connection failed.