### PR TITLE
Prereq JRE is not present in base image. Preinstalling it.

### DIFF
--- a/scripts/linux/install-cassandra.sh
+++ b/scripts/linux/install-cassandra.sh
@@ -22,7 +22,7 @@ echo seed_node_dns_name $seed_node_dns_name
 echo data_center_name $data_center_name
 echo opscenter_dns_name $opscenter_dns_name
 
-apt-get -y install unzip
+apt-get -y install unzip default-jre
 
 wget https://github.com/DSPN/install-datastax-ubuntu/archive/master.zip
 unzip master.zip

--- a/scripts/linux/install-opscenter.sh
+++ b/scripts/linux/install-opscenter.sh
@@ -15,7 +15,7 @@ echo "Calling opscenter.sh with the settings:"
 echo cloud_type $cloud_type
 echo seed_node_dns_name $seed_node_dns_name
 
-apt-get -y install unzip
+apt-get -y install unzip default-jre
 
 wget https://github.com/DSPN/install-datastax-ubuntu/archive/master.zip
 unzip master.zip


### PR DESCRIPTION
If JRE is not present, neither Cassandra cluster nor Datastax OpsCenter properly start. Causing the deployment to fail (by timeout).

Adding  default-jre to both install-cassandra and install-opscenter scripts, fixes it.