### PR TITLE
Fixed data disk discovery issues (read details)

### DIFF
--- a/virtual-machines/n-tier-windows/PrepareSQLServer-AGDB.ps1
+++ b/virtual-machines/n-tier-windows/PrepareSQLServer-AGDB.ps1
@@ -54,16 +54,19 @@ configuration SQLServerDBDsc
     {
         if ($ClusterOwnerNode -eq $env:COMPUTERNAME)
         {
+            $uniqueid = Get-Disk | Where-Object { $_.FriendlyName -like 'Msft Virtual Disk' } | Select-Object -First 1 -ExpandProperty UniqueId
             WaitforDisk Disk2
             {
-                DiskId = 2
+                DiskId = $uniqueid
+                DiskIdType = 'UniqueId'
                 RetryIntervalSec = 60
                 RetryCount = 20
             }
 
             Disk FVolume
             {
-                DiskId = 2
+                DiskId = $uniqueid
+                DiskIdType = 'UniqueId'
                 DriveLetter = 'F'
                 FSLabel = 'Data'
                 FSFormat = 'NTFS'


### PR DESCRIPTION
Using the numeric id, causes an erratic behaviour from time to time. We are using UniqueId both at WaitForDisk and Disk DSC Resources (read into linked material for more details).

* https://github.com/PowerShell/StorageDsc/tree/dev/DSCResources/MSFT_WaitForDisk
* https://github.com/PowerShell/StorageDsc/tree/dev/DSCResources/MSFTDSC_Disk