### PR TITLE
(AzureCXP) fix templates to accommodate linux users

### DIFF
--- a/hybrid-networking/hub-spoke/hub-firewall.json
+++ b/hybrid-networking/hub-spoke/hub-firewall.json
@@ -49,7 +49,7 @@
                             },
                             "rules": [
                                 {
-                                    "name": "AllowRDP-Spoke1",
+                                    "name": "AllowRemote-Spoke1",
                                     "protocols": [
                                         "TCP"
                                     ],
@@ -60,11 +60,12 @@
                                         "10.1.0.0/16"
                                     ],
                                     "destinationPorts": [
+                                        "22",
                                         "3389"
                                     ]
                                 },
                                 {
-                                    "name": "AllowRDP-Spoke2",
+                                    "name": "AllowRemote-Spoke2",
                                     "protocols": [
                                         "TCP"
                                     ],
@@ -75,6 +76,7 @@
                                         "10.2.0.0/16"
                                     ],
                                     "destinationPorts": [
+                                        "22",
                                         "3389"
                                     ]
                                 }
@@ -90,7 +92,7 @@
                             },
                             "rules": [
                                 {
-                                    "name": " AllowRDP-Spoke1-Spoke2",
+                                    "name": " AllowRemote-Spoke1-Spoke2",
                                     "protocols": [
                                         "TCP"
                                     ],
@@ -101,11 +103,12 @@
                                         "10.2.0.0/16"
                                     ],
                                     "destinationPorts": [
+                                        "22",
                                         "3389"
                                     ]
                                 },
                                 {
-                                    "name": "AllowRDP-Spoke2-Spoke1",
+                                    "name": "AllowRemote-Spoke2-Spoke1",
                                     "protocols": [
                                         "TCP"
                                     ],
@@ -116,6 +119,7 @@
                                         "10.1.0.0/16"
                                     ],
                                     "destinationPorts": [
+                                        "22",
                                         "3389"
                                     ]
                                 }


### PR DESCRIPTION
This PR includes firewall rules that allow SSH and ICMP between spokes.

resolves MicrosoftDocs/architecture-center#1642

@MikeWasson Could you please review this? I guess an alternative to this PR, if required, would be to add a note in the doc describing this change.