### PR TITLE
Fcp/aks baseline keyvault

### DIFF
--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -51,6 +51,12 @@
         "kubernetesVersion": {
             "defaultValue": "1.17.3",
             "type": "string"
+        },
+        "allowedSubnetNames": {
+            "type": "string",
+            "metadata": {
+                "description": "Comma separated subnet names that can access the key vault."
+            }
         }
     },
     "variables": {
@@ -78,9 +84,39 @@
         "clusterMonitoringMetricsPublisherRoleAssignmentName": "[concat(variables('clusterName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('monitoringMetricsPublisherRole')))]",
         "networkRoleAssignmentName": "[concat(variables('vNetName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('networkContributorRole')))]",
         "acrRoleAssignmentName": "[concat(variables('defaultAcrName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('acrPullRole')))]",
-        "dnsPrefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, variables('clusterName'))]"
+        "dnsPrefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, variables('clusterName'))]",
+        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id),'1' ) ]",
+        "allowedSubnetNamesArray": "[split(parameters('allowedSubnetNames'), ',')]"
     },
     "resources": [
+        {
+            "type": "Microsoft.KeyVault/vaults",
+            "name": "[variables('keyVaultName')]",
+            "apiVersion": "2019-09-01",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accessPolicies": [
+                ],
+                "sku": {
+                    "family": "A",
+                    "name": "standard"
+                },
+                "tenantId": "[subscription().tenantId]",
+                "networkAcls": {
+                    "bypass": "AzureServices",
+                    "defaultAction": "Deny",
+                    "copy": [
+                        {
+                            "name": "virtualNetworkRules",
+                            "count": "[length(variables('allowedSubnetNamesArray'))]",
+                            "input": {
+                                "id": "[resourceId(variables('vNetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('allowedSubnetNamesArray')[copyIndex('virtualNetworkRules')])]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
         {
             "type": "Microsoft.Resources/deployments",
             "name": "EnsureClusterSpHasRbacToVNet",

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -52,10 +52,10 @@
             "defaultValue": "1.17.3",
             "type": "string"
         },
-        "allowedSubnetNames": {
+        "firewallSubnetResourceId": {
             "type": "string",
             "metadata": {
-                "description": "Comma separated subnet names that can access the key vault."
+                "description": "the firewall subnet to give access to the key vault."
             }
         }
     },
@@ -85,8 +85,7 @@
         "networkRoleAssignmentName": "[concat(variables('vNetName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('networkContributorRole')))]",
         "acrRoleAssignmentName": "[concat(variables('defaultAcrName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('acrPullRole')))]",
         "dnsPrefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, variables('clusterName'))]",
-        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id)) ]",
-        "allowedSubnetNamesArray": "[split(parameters('allowedSubnetNames'), ',')]"
+        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id),'-4') ]"
     },
     "resources": [
         {
@@ -105,13 +104,9 @@
                 "networkAcls": {
                     "bypass": "AzureServices",
                     "defaultAction": "Deny",
-                    "copy": [
+                    "virtualNetworkRules": [
                         {
-                            "name": "virtualNetworkRules",
-                            "count": "[length(variables('allowedSubnetNamesArray'))]",
-                            "input": {
-                                "id": "[resourceId(variables('vNetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('allowedSubnetNamesArray')[copyIndex('virtualNetworkRules')])]"
-                            }
+                            "id": "[parameters('firewallSubnetResourceId')]"
                         }
                     ]
                 }

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -52,10 +52,10 @@
             "defaultValue": "1.17.3",
             "type": "string"
         },
-        "firewallSubnetResourceId": {
-            "type": "string",
+        "keyvaultAclAllowedSubnetResourceIds": {
+            "type": "array",
             "metadata": {
-                "description": "the firewall subnet to give access to the key vault."
+                "description": "the subnets to give access to the key vault."
             }
         }
     },
@@ -85,7 +85,7 @@
         "networkRoleAssignmentName": "[concat(variables('vNetName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('networkContributorRole')))]",
         "acrRoleAssignmentName": "[concat(variables('defaultAcrName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('acrPullRole')))]",
         "dnsPrefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, variables('clusterName'))]",
-        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id),'-4') ]"
+        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id)) ]"
     },
     "resources": [
         {
@@ -102,11 +102,15 @@
                 },
                 "tenantId": "[subscription().tenantId]",
                 "networkAcls": {
-                    "bypass": "AzureServices",
+                    "bypass": "None",
                     "defaultAction": "Deny",
-                    "virtualNetworkRules": [
+                    "copy": [
                         {
-                            "id": "[parameters('firewallSubnetResourceId')]"
+                            "name": "virtualNetworkRules",
+                            "count": "[length(parameters('keyvaultAclAllowedSubnetResourceIds'))]",
+                            "input": {
+                                "id": "[parameters('keyvaultAclAllowedSubnetResourceIds')[copyIndex('virtualNetworkRules')]]"
+                            }
                         }
                     ]
                 }

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -85,7 +85,7 @@
         "networkRoleAssignmentName": "[concat(variables('vNetName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('networkContributorRole')))]",
         "acrRoleAssignmentName": "[concat(variables('defaultAcrName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('acrPullRole')))]",
         "dnsPrefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, variables('clusterName'))]",
-        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id),'1' ) ]",
+        "keyVaultName": "[concat( 'keyvault-', uniqueString(resourceGroup().id)) ]",
         "allowedSubnetNamesArray": "[split(parameters('allowedSubnetNames'), ',')]"
     },
     "resources": [

--- a/aks/secure-baseline/deleteResourceGroups.sh
+++ b/aks/secure-baseline/deleteResourceGroups.sh
@@ -7,8 +7,8 @@ RGNAMECLUSTER=rg-cluster01
 echo deleting $RGNAMECLUSTER
 az group delete -n $RGNAMECLUSTER --yes
 
-echo deleting $RGNAMESPOKES
-az group delete -n $RGNAMESPOKES --yes
-
 echo deleting $RGNAME
 az group delete -n $RGNAME --yes
+
+echo deleting $RGNAMESPOKES
+az group delete -n $RGNAMESPOKES --yes

--- a/aks/secure-baseline/deploy.sh
+++ b/aks/secure-baseline/deploy.sh
@@ -61,16 +61,12 @@ az deployment group create --resource-group "${RGNAME}" --template-file "./netwo
 
 HUB_VNET_ID=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubVnetId.value -o tsv)
 
-HUB_FW_NAME=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubFwName.value -o tsv)
-
-HUB_LA_NAME=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubLaName.value -o tsv)
-
 FIREWALL_SUBNET_RESOURCEID=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubfwSubnetResourceId.value -o tsv)
  
 #Cluster Subnet.Build the spoke. Second arm template execution and catching outputs. This might take about 2 minutes
 az group create --name "${RGNAMESPOKES}" --location "${RGLOCATION}"
 
-az deployment group  create --resource-group "${RGNAMESPOKES}" --template-file "./networking/spoke-BU0001A0008.json" --name "spoke-0001" --parameters location=$RGLOCATION hubVnetResourceId=$HUB_VNET_ID hubFwName=$HUB_FW_NAME hubLaName=$HUB_LA_NAME
+az deployment group  create --resource-group "${RGNAMESPOKES}" --template-file "./networking/spoke-BU0001A0008.json" --name "spoke-0001" --parameters location=$RGLOCATION hubVnetResourceId=$HUB_VNET_ID
 
 CLUSTER_VNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.clusterVnetResourceId.value -o tsv)
 
@@ -92,6 +88,7 @@ az group create --name "${RGNAMECLUSTER}" --location "${RGLOCATION}"
 
 # Cluster Parameters
 echo "CLUSTER_VNET_RESOURCE_ID=${CLUSTER_VNET_RESOURCE_ID}"
+echo "RGNAMECLUSTER=${RGNAMECLUSTER}"
 echo "RGLOCATION=${RGLOCATION}"
 echo "FIREWALL_SUBNET_RESOURCEID=${FIREWALL_SUBNET_RESOURCEID}"
 echo "k8sRbacAadProfileServerAppId=${k8sRbacAadProfileServerAppId}"
@@ -99,4 +96,4 @@ echo "k8sRbacAadProfileClientAppId=${k8sRbacAadProfileClientAppId}"
 echo "k8sRbacAadProfileServerAppSecret=${k8sRbacAadProfileServerAppSecret}"
 echo "k8sRbacAadProfileTennetId=${k8sRbacAadProfileTennetId}"
 
-az deployment group create --resource-group "${RGNAMECLUSTER}" --template-file "cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$CLUSTER_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId firewallSubnetResourceId=$FIREWALL_SUBNET_RESOURCEID
+az deployment group create --resource-group "${RGNAMECLUSTER}" --template-file "cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$CLUSTER_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId keyvaultAclAllowedSubnetResourceIds="['$FIREWALL_SUBNET_RESOURCEID']"

--- a/aks/secure-baseline/deploy.sh
+++ b/aks/secure-baseline/deploy.sh
@@ -14,6 +14,7 @@ clientAppName=${aksName}-kubectl-${runDate}
 tenant_guid=**Your tenant id for Identities**
 main_subscription=**Your Main subscription**
 
+
 # We are going to use a new tenant to provide identity
 az login  --allow-no-subscriptions -t $tenant_guid
 #--Until change the subscription It will take about 1 minutes creating service principals
@@ -99,4 +100,4 @@ echo "k8sRbacAadProfileClientAppId=${k8sRbacAadProfileClientAppId}"
 echo "k8sRbacAadProfileServerAppSecret=${k8sRbacAadProfileServerAppSecret}"
 echo "k8sRbacAadProfileTennetId=${k8sRbacAadProfileTennetId}"
 
-az deployment group  create --resource-group "${RGNAMECLUSTER}" --template-file "004-cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$TARGET_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId
+az deployment group  create --resource-group "${RGNAMECLUSTER}" --template-file "004-cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$TARGET_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId allowedSubnetNames="snet-system-clusternodes,snet-user-clusternodes,snet-clusteringressservices,snet-applicationgateways"

--- a/aks/secure-baseline/deploy.sh
+++ b/aks/secure-baseline/deploy.sh
@@ -1,11 +1,9 @@
 # This script might take about 20 minutes
 # Please check the variables
 RGLOCATION=eastus
-VNET_NAME=vnet-hub
 RGNAME=rg-enterprise-networking-hubs
 RGNAMESPOKES=rg-enterprise-networking-spokes
 RGNAMECLUSTER=rg-cluster01
-AKSNAME=akssp
 aksName=cluster01
 runDate=$(date +%S%N)
 spName=${aksName}-sp-${runDate}
@@ -52,6 +50,11 @@ az ad app permission grant --id $k8sRbacAadProfileClientAppId --api $k8sRbacAadP
 
 k8sRbacAadProfileTennetId=$(az account show --query tenantId -o tsv)
 
+echo "k8sRbacAadProfileServerAppId=${k8sRbacAadProfileServerAppId}"
+echo "k8sRbacAadProfileClientAppId=${k8sRbacAadProfileClientAppId}"
+echo "k8sRbacAadProfileServerAppSecret=${k8sRbacAadProfileServerAppSecret}"
+echo "k8sRbacAadProfileTennetId=${k8sRbacAadProfileTennetId}"
+
 #back to main subscription
 az login 
 az account set -s $main_subscription
@@ -59,45 +62,42 @@ az account set -s $main_subscription
 #Main Network.Build the hub. First arm template execution and catching outputs. This might take about 6 minutes
 az group create --name "${RGNAME}" --location "${RGLOCATION}"
 
-az deployment group create --resource-group "${RGNAME}" --template-file "001-enterprise-hub-stamp (pre network-stamp).json"  --name "hub-0001" --parameters location=$RGLOCATION hubVnetName=$VNET_NAME
-
-FIREWALL_NAME=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.firewallName.value -o tsv)
-
-HUB_LA_RESOURCE_ID=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubLaResourceId.value -o tsv)
+az deployment group create --resource-group "${RGNAME}" --template-file "./networking/hub-default.json"  --name "hub-0001" --parameters location=$RGLOCATION
 
 HUB_VNET_ID=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubVnetId.value -o tsv)
 
+HUB_FW_NAME=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubFwName.value -o tsv)
+
+HUB_LA_NAME=$(az deployment group show -g $RGNAME -n hub-0001 --query properties.outputs.hubLaName.value -o tsv)
+ 
 #Cluster Subnet.Build the spoke. Second arm template execution and catching outputs. This might take about 2 minutes
 az group create --name "${RGNAMESPOKES}" --location "${RGLOCATION}"
 
-az deployment group  create --resource-group "${RGNAMESPOKES}" --template-file "002-cluster-network-stamp.json" --name "spoke-0001" --parameters location=$RGLOCATION hubLaResourceId=$HUB_LA_RESOURCE_ID hubVnetId=$HUB_VNET_ID firewallName=$FIREWALL_NAME
+az deployment group  create --resource-group "${RGNAMESPOKES}" --template-file "./networking/spoke-BU0001A0008.json" --name "spoke-0001" --parameters location=$RGLOCATION hubVnetResourceId=$HUB_VNET_ID hubFwName=$HUB_FW_NAME hubLaName=$HUB_LA_NAME
 
-TARGET_VNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.targetVnetResourceId.value -o tsv)
+CLUSTER_VNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.clusterVnetResourceId.value -o tsv)
 
-VNET_NODEPOOL_SUBNET_NAME=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.vnetNodepoolSubnetName.value -o tsv)
+USER_NODEPOOL_SUBNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.userNodepoolSubnetResourceIds.value -o tsv)
 
-VNET_NODEPOOL_SUBNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.vnetNodepoolSubnetNameResourceId.value -o tsv)
+SYSTEM_NODEPOOL_SUBNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.systemNodepoolSubnetResourceIds.value -o tsv)
+
+GATEWAY_SUBNET_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.vnetGatewaySubnetResourceIds.value -o tsv)
+
+GATEWAY_PUbLIC_IP_RESOURCE_ID=$(az deployment group show -g $RGNAMESPOKES -n spoke-0001 --query properties.outputs.appGatewayPipResourceIds.value -o tsv)
 
 #Main Network Update. Third arm template execution and catching outputs. This might take about 3 minutes
 
-az deployment group create --resource-group "${RGNAME}" --template-file "003-enterprise-hub-stamp (post network-stamp).json" --name "hub-0002" --parameters location=$RGLOCATION hubVnetName=$VNET_NAME vnetNodepoolSubnetNameResourceId=$VNET_NODEPOOL_SUBNET_RESOURCE_ID
-
-FIREWALL_NAME=$(az deployment group show -g $RGNAME -n hub-0002 --query properties.outputs.firewallName.value -o tsv)
-
-HUB_LA_RESOURCE_ID=$(az deployment group show -g $RGNAME -n hub-0002 --query properties.outputs.hubLaResourceId.value -o tsv)
-
-HUB_VNET_ID=$(az deployment group show -g $RGNAME -n hub-0002 --query properties.outputs.hubVnetId.value -o tsv)
+az deployment group create --resource-group "${RGNAME}" --template-file  "./networking/hub-regionA.json" --name "hub-0002" --parameters location=$RGLOCATION nodepoolSubnetResourceIds="['$USER_NODEPOOL_SUBNET_RESOURCE_ID','$SYSTEM_NODEPOOL_SUBNET_RESOURCE_ID']"
 
 #AKS Cluster Creation. Advance Networking. AAD identity integration. This might take about 8 minutes
 az group create --name "${RGNAMECLUSTER}" --location "${RGLOCATION}"
 
 # Cluster Parameters
-echo "TARGET_VNET_RESOURCE_ID=${TARGET_VNET_RESOURCE_ID}"
+echo "CLUSTER_VNET_RESOURCE_ID=${CLUSTER_VNET_RESOURCE_ID}"
 echo "RGLOCATION=${RGLOCATION}"
-echo "RGNAMECLUSTER=${RGNAMECLUSTER}"
 echo "k8sRbacAadProfileServerAppId=${k8sRbacAadProfileServerAppId}"
 echo "k8sRbacAadProfileClientAppId=${k8sRbacAadProfileClientAppId}"
 echo "k8sRbacAadProfileServerAppSecret=${k8sRbacAadProfileServerAppSecret}"
 echo "k8sRbacAadProfileTennetId=${k8sRbacAadProfileTennetId}"
 
-az deployment group  create --resource-group "${RGNAMECLUSTER}" --template-file "004-cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$TARGET_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId allowedSubnetNames="snet-system-clusternodes,snet-user-clusternodes,snet-clusteringressservices,snet-applicationgateways"
+az deployment group create --resource-group "${RGNAMECLUSTER}" --template-file "cluster-stamp.json" --name "cluster-0001" --parameters location=$RGLOCATION targetVnetResourceId=$CLUSTER_VNET_RESOURCE_ID k8sRbacAadProfileServerAppId=$k8sRbacAadProfileServerAppId k8sRbacAadProfileServerAppSecret=$k8sRbacAadProfileServerAppSecret k8sRbacAadProfileClientAppId=$k8sRbacAadProfileClientAppId k8sRbacAadProfileTennetId=$k8sRbacAadProfileTennetId allowedSubnetNames="snet-system-clusternodes,snet-user-clusternodes,snet-clusteringressservices,snet-applicationgateways"

--- a/aks/secure-baseline/networking/hub-default.json
+++ b/aks/secure-baseline/networking/hub-default.json
@@ -83,6 +83,9 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
+                                },
+                                {
+                                    "service": "Microsoft.KeyVault"
                                 }
                             ]
                         }
@@ -294,6 +297,10 @@
         },
         "hubLaName": {
             "value": "[variables('hubLaName')]",
+            "type": "string"
+        },
+        "hubfwSubnetResourceId": {
+            "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('hubVnetName'), 'AzureFirewallSubnet')]",
             "type": "string"
         }
     }

--- a/aks/secure-baseline/networking/hub-default.json
+++ b/aks/secure-baseline/networking/hub-default.json
@@ -58,10 +58,10 @@
         }
     },
     "variables": {
-        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default-', uniqueString(resourceGroup().id))]",
-        "hubFwName": "[concat('fw-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
-        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]"
+        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
+        "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
+        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]"
     },
     "resources": [
         {
@@ -289,14 +289,6 @@
     "outputs": {
         "hubVnetId": {
             "value": "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
-            "type": "string"
-        },
-        "hubFwName": {
-            "value": "[variables('hubFwName')]",
-            "type": "string"
-        },
-        "hubLaName": {
-            "value": "[variables('hubLaName')]",
             "type": "string"
         },
         "hubfwSubnetResourceId": {

--- a/aks/secure-baseline/networking/hub-default.json
+++ b/aks/secure-baseline/networking/hub-default.json
@@ -58,10 +58,10 @@
         }
     },
     "variables": {
-        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
-        "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
-        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]"
+        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default-', uniqueString(resourceGroup().id))]",
+        "hubFwName": "[concat('fw-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
+        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]"
     },
     "resources": [
         {
@@ -91,14 +91,16 @@
                         "name": "GatewaySubnet",
                         "properties": {
                             "addressPrefix": "[parameters('azureGatewaySubnetAddressSpace')]",
-                            "serviceEndpoints": [ ]
+                            "serviceEndpoints": [
+                            ]
                         }
                     },
                     {
                         "name": "AzureBastionSubnet",
                         "properties": {
                             "addressPrefix": "[parameters('azureBastionSubnetAddressSpace')]",
-                            "serviceEndpoints": [ ]
+                            "serviceEndpoints": [
+                            ]
                         }
                     }
                 ],
@@ -282,24 +284,16 @@
         }
     ],
     "outputs": {
-        "firewallPipName": {
-            "value": "[variables('defaultFwPipName')]",
-            "type": "string"
-        },
-        "hubLaResourceId": {
-            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
-            "type": "string"
-        },
-        "hubVnetName": {
-            "value": "[variables('hubVnetName')]",
-            "type": "string"
-        },
         "hubVnetId": {
             "value": "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
             "type": "string"
         },
-        "firewallName": {
+        "hubFwName": {
             "value": "[variables('hubFwName')]",
+            "type": "string"
+        },
+        "hubLaName": {
+            "value": "[variables('hubLaName')]",
             "type": "string"
         }
     }

--- a/aks/secure-baseline/networking/hub-regionA.json
+++ b/aks/secure-baseline/networking/hub-regionA.json
@@ -65,11 +65,11 @@
         }
     },
     "variables": {
-        "aksIpGroupName": "[concat('ipg-', parameters('location'), '-AksNodepools')]",
-        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
-        "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
-        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]"
+        "aksIpGroupName": "[concat('ipg-', parameters('location'), '-AksNodepools', uniqueString(resourceGroup().id))]",
+        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default-', uniqueString(resourceGroup().id))]",
+        "hubFwName": "[concat('fw-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
+        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]"
     },
     "resources": [
         {
@@ -99,14 +99,16 @@
                         "name": "GatewaySubnet",
                         "properties": {
                             "addressPrefix": "[parameters('azureGatewaySubnetAddressSpace')]",
-                            "serviceEndpoints": [ ]
+                            "serviceEndpoints": [
+                            ]
                         }
                     },
                     {
                         "name": "AzureBastionSubnet",
                         "properties": {
                             "addressPrefix": "[parameters('azureBastionSubnetAddressSpace')]",
-                            "serviceEndpoints": [ ]
+                            "serviceEndpoints": [
+                            ]
                         }
                     }
                 ],
@@ -517,24 +519,16 @@
         }
     ],
     "outputs": {
-        "firewallPipName": {
-            "value": "[variables('defaultFwPipName')]",
-            "type": "string"
-        },
-        "hubLaResourceId": {
-            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
-            "type": "string"
-        },
-        "hubVnetName": {
-            "value": "[variables('hubVnetName')]",
-            "type": "string"
-        },
         "hubVnetId": {
             "value": "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
             "type": "string"
         },
-        "firewallName": {
+        "hubFwName": {
             "value": "[variables('hubFwName')]",
+            "type": "string"
+        },
+        "hubLaName": {
+            "value": "[variables('hubLaName')]",
             "type": "string"
         }
     }

--- a/aks/secure-baseline/networking/hub-regionA.json
+++ b/aks/secure-baseline/networking/hub-regionA.json
@@ -62,6 +62,16 @@
             "metadata": {
                 "description": "Subnet resource Ids for all AKS clusters nodepools in all attached spokes to allow necessary outbound traffic through the firewall"
             }
+        },
+        "keyVaultSubnetsResourceIds": {
+            "type": "array",
+            "metadata": {
+                "description": "Subnet resource Ids for all AKS clusters subnets to allow necessary outbound traffic through the firewall"
+            }
+        },
+        "serviceTagLocation": {
+            "type": "string",
+            "defaultValue": "EastUS2"
         }
     },
     "variables": {
@@ -69,7 +79,8 @@
         "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default-', uniqueString(resourceGroup().id))]",
         "hubFwName": "[concat('fw-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
         "hubVNetName": "[concat('vnet-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]"
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]",
+        "keyVaultIpGroupName": "[concat('keyvault-ipg-', uniqueString(resourceGroup().id))]"
     },
     "resources": [
         {
@@ -91,6 +102,9 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
+                                },
+                                {
+                                    "service": "Microsoft.KeyVault"
                                 }
                             ]
                         }
@@ -146,6 +160,21 @@
             }
         },
         {
+            "type": "Microsoft.Network/ipGroups",
+            "apiVersion": "2019-11-01",
+            "location": "[parameters('location')]",
+            "name": "[variables('keyVaultIpGroupName')]",
+            "properties": {
+                "copy": [
+                    {
+                        "name": "ipAddresses",
+                        "count": "[length(parameters('keyVaultSubnetsResourceIds'))]",
+                        "input": "[reference(parameters('keyVaultSubnetsResourceIds')[copyIndex('ipAddresses')], '2019-11-01').addressPrefix]"
+                    }
+                ]
+            }
+        },
+        {
             "type": "Microsoft.Network/azureFirewalls",
             "apiVersion": "2019-11-01",
             "name": "[variables('hubFwName')]",
@@ -158,7 +187,8 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Network/publicIpAddresses', variables('defaultFwPipName'))]",
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
-                "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]",
+                "[resourceId('Microsoft.Network/ipGroups', variables('keyVaultIpGroupName'))]"
             ],
             "properties": {
                 "sku": {
@@ -279,6 +309,27 @@
                                     ],
                                     "destinationAddresses": [
                                         "*"
+                                    ]
+                                },
+                                {
+                                    "name": "aks-keyvault",
+                                    "protocols": [
+                                        "TCP"
+                                    ],
+                                    "sourceAddresses": [
+                                    ],
+                                    "destinationAddresses": [
+                                        "[concat('AzureKeyVault.',parameters('serviceTagLocation'))]"
+                                    ],
+                                    "sourceIpGroups": [
+                                        "[resourceId('Microsoft.Network/ipGroups', variables('keyVaultIpGroupName'))]"
+                                    ],
+                                    "destinationIpGroups": [
+                                    ],
+                                    "destinationFqdns": [
+                                    ],
+                                    "destinationPorts": [
+                                        "443"
                                     ]
                                 }
                             ]
@@ -529,6 +580,10 @@
         },
         "hubLaName": {
             "value": "[variables('hubLaName')]",
+            "type": "string"
+        },
+        "hubfwSubnetResourceId": {
+            "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('hubVnetName'), 'AzureFirewallSubnet')]",
             "type": "string"
         }
     }

--- a/aks/secure-baseline/networking/hub-regionA.json
+++ b/aks/secure-baseline/networking/hub-regionA.json
@@ -75,12 +75,12 @@
         }
     },
     "variables": {
-        "aksIpGroupName": "[concat('ipg-', parameters('location'), '-AksNodepools', uniqueString(resourceGroup().id))]",
-        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default-', uniqueString(resourceGroup().id))]",
-        "hubFwName": "[concat('fw-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
-        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub-', uniqueString(resourceGroup().id))]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-', uniqueString(resourceGroup().id))]",
-        "keyVaultIpGroupName": "[concat('keyvault-ipg-', uniqueString(resourceGroup().id))]"
+        "aksIpGroupName": "[concat('ipg-', parameters('location'), '-AksNodepools')]",
+        "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
+        "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
+        "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]",
+        "keyVaultIpGroupName": "[concat('keyvault-ipg')]"
     },
     "resources": [
         {
@@ -572,14 +572,6 @@
     "outputs": {
         "hubVnetId": {
             "value": "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
-            "type": "string"
-        },
-        "hubFwName": {
-            "value": "[variables('hubFwName')]",
-            "type": "string"
-        },
-        "hubLaName": {
-            "value": "[variables('hubLaName')]",
             "type": "string"
         },
         "hubfwSubnetResourceId": {

--- a/aks/secure-baseline/networking/spoke-BU0001A0008.json
+++ b/aks/secure-baseline/networking/spoke-BU0001A0008.json
@@ -22,6 +22,12 @@
         },
         "hubVnetResourceId": {
             "type": "string"
+        },
+        "hubFwName": {
+            "type": "string"
+        },
+        "hubLaName": {
+            "type": "string"
         }
     },
     "variables": {
@@ -54,7 +60,7 @@
                         "properties": {
                             "nextHopType": "VirtualAppliance",
                             "addressPrefix": "0.0.0.0/0",
-                            "nextHopIpAddress": "[reference(resourceId(variables('hubRgName'), 'Microsoft.Network/azureFirewalls', concat('fw-', parameters('location'), '-hub')), '2019-11-01', 'Full').properties.ipConfigurations[0].properties.privateIpAddress]"
+                            "nextHopIpAddress": "[reference(resourceId(variables('hubRgName'), 'Microsoft.Network/azureFirewalls', parameters('hubFwName')), '2019-11-01', 'Full').properties.ipConfigurations[0].properties.privateIpAddress]"
                         }
                     }
                 ]
@@ -163,7 +169,7 @@
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]"
             ],
             "properties": {
-                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', concat('la-networking-hub-', reference(parameters('hubVnetResourceId'), '2019-11-01', 'Full').location))]",
+                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', parameters('hubLaName'))]",
                 "metrics": [
                     {
                         "category": "AllMetrics",
@@ -231,6 +237,14 @@
         },
         "systemNodepoolSubnetResourceIds": {
             "value": "[createArray(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('clusterVNetName'), variables('vnetNodepoolSubnetName')))]",
+            "type": "array"
+        },
+        "vnetGatewaySubnetResourceIds": {
+            "value": "[createArray(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('clusterVNetName'), variables('vnetGatewaySubnetName')))]",
+            "type": "array"
+        },
+        "appGatewayPipResourceIds": {
+            "value": "[createArray(resourceId('Microsoft.Network/publicIpAddresses', variables('appGatewayPipName')))]",
             "type": "array"
         }
     }

--- a/aks/secure-baseline/networking/spoke-BU0001A0008.json
+++ b/aks/secure-baseline/networking/spoke-BU0001A0008.json
@@ -82,6 +82,9 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
+                                },
+                                {
+                                    "service": "Microsoft.KeyVault"
                                 }
                             ],
                             "routeTable": {
@@ -96,6 +99,9 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
+                                },
+                                {
+                                    "service": "Microsoft.KeyVault"
                                 }
                             ],
                             "routeTable": {
@@ -106,13 +112,23 @@
                     {
                         "name": "[variables('vnetIngressSubnetName')]",
                         "properties": {
-                            "addressPrefix": "[variables('vnetIngressSubnetAddressSpace')]"
+                            "addressPrefix": "[variables('vnetIngressSubnetAddressSpace')]",
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.KeyVault"
+                                }
+                            ]
                         }
                     },
                     {
                         "name": "[variables('vnetGatewaySubnetName')]",
                         "properties": {
-                            "addressPrefix": "[variables('vnetGatewaySubnetAddressSpace')]"
+                            "addressPrefix": "[variables('vnetGatewaySubnetAddressSpace')]",
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.KeyVault"
+                                }
+                            ]
                         }
                     }
                 ],

--- a/aks/secure-baseline/networking/spoke-BU0001A0008.json
+++ b/aks/secure-baseline/networking/spoke-BU0001A0008.json
@@ -88,9 +88,6 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
-                                },
-                                {
-                                    "service": "Microsoft.KeyVault"
                                 }
                             ],
                             "routeTable": {
@@ -105,9 +102,6 @@
                             "serviceEndpoints": [
                                 {
                                     "service": "Microsoft.ContainerRegistry"
-                                },
-                                {
-                                    "service": "Microsoft.KeyVault"
                                 }
                             ],
                             "routeTable": {
@@ -118,23 +112,13 @@
                     {
                         "name": "[variables('vnetIngressSubnetName')]",
                         "properties": {
-                            "addressPrefix": "[variables('vnetIngressSubnetAddressSpace')]",
-                            "serviceEndpoints": [
-                                {
-                                    "service": "Microsoft.KeyVault"
-                                }
-                            ]
+                            "addressPrefix": "[variables('vnetIngressSubnetAddressSpace')]"
                         }
                     },
                     {
                         "name": "[variables('vnetGatewaySubnetName')]",
                         "properties": {
-                            "addressPrefix": "[variables('vnetGatewaySubnetAddressSpace')]",
-                            "serviceEndpoints": [
-                                {
-                                    "service": "Microsoft.KeyVault"
-                                }
-                            ]
+                            "addressPrefix": "[variables('vnetGatewaySubnetAddressSpace')]"
                         }
                     }
                 ],

--- a/aks/secure-baseline/networking/spoke-BU0001A0008.json
+++ b/aks/secure-baseline/networking/spoke-BU0001A0008.json
@@ -22,12 +22,6 @@
         },
         "hubVnetResourceId": {
             "type": "string"
-        },
-        "hubFwName": {
-            "type": "string"
-        },
-        "hubLaName": {
-            "type": "string"
         }
     },
     "variables": {
@@ -45,7 +39,8 @@
         "routeTableName": "[concat('route-', variables('clusterVNetName'), '-clusternodes-to-hub')]",
         "hubRgName": "[split(parameters('hubVnetResourceId'),'/')[4]]",
         "hubNetworkName": "[split(parameters('hubVnetResourceId'),'/')[8]]",
-        "appGatewayPipName": "[concat('pip-', variables('orgAppId'), '-00')]"
+        "appGatewayPipName": "[concat('pip-', variables('orgAppId'), '-00')]",
+        "hubFwName": "[concat('fw-', parameters('location'), '-hub')]"
     },
     "resources": [
         {
@@ -60,7 +55,7 @@
                         "properties": {
                             "nextHopType": "VirtualAppliance",
                             "addressPrefix": "0.0.0.0/0",
-                            "nextHopIpAddress": "[reference(resourceId(variables('hubRgName'), 'Microsoft.Network/azureFirewalls', parameters('hubFwName')), '2019-11-01', 'Full').properties.ipConfigurations[0].properties.privateIpAddress]"
+                            "nextHopIpAddress": "[reference(resourceId(variables('hubRgName'), 'Microsoft.Network/azureFirewalls', variables('hubFwName')), '2019-11-01', 'Full').properties.ipConfigurations[0].properties.privateIpAddress]"
                         }
                     }
                 ]
@@ -153,7 +148,7 @@
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]"
             ],
             "properties": {
-                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', parameters('hubLaName'))]",
+                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', concat('la-networking-hub-', reference(parameters('hubVnetResourceId'), '2019-11-01', 'Full').location))]",
                 "metrics": [
                     {
                         "category": "AllMetrics",


### PR DESCRIPTION
The key vault is in place. 
The firewall network is able to access the key vault, and there is a rule that allow only some aks cluster subnets access to it. 

-Updated end to end script
Note: I face an issue on a firewall, I'm not able to delete it and its dependencies. I have created a support ticket on the azure portal and try the deploy out on another rg, same region. 
I faced an issue with a name which already exist. I put a resource group id as part of some resource names (uniqueString(resourceGroup().id) in order to avoid that issue.

Instead of suppose some name in spoke-BU0001A0008.json, I received as parameter that names (firewall and hubLaName) generated in the step before. 

