### PR TITLE
Add a basic workload

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -10,6 +10,9 @@
 The following example creates the ASPNET Core Docker sample web app and an Ingress object to route to its service.
 
 ```bash
+# Create application namespace
+kubectl create ns a0008
+
 # Apply the contents
 kubectl apply -f https://github.com/mspnp/reference-architectures/tree/fcp/aks-baseline/aks/secure-baseline/workload/aspnetapp.yaml
 ```
@@ -17,7 +20,7 @@ kubectl apply -f https://github.com/mspnp/reference-architectures/tree/fcp/aks-b
 Now the ASPNET Core webapp sample is all setup. Wait until is ready to process requests running:
 
 ```bash
-kubectl wait --namespace default \
+kubectl wait --namespace a0008 \
   --for=condition=ready pod \
   --selector=app=aspnetapp \
   --timeout=90s

--- a/aks/README.md
+++ b/aks/README.md
@@ -18,7 +18,7 @@ The following example creates the ASPNET Core Docker sample web app and an Ingre
 kubectl create ns a0008
 
 # Apply the contents
-kubectl apply -f https://github.com/mspnp/reference-architectures/tree/fcp/aks-baseline/aks/secure-baseline/workload/aspnetapp.yaml
+kubectl apply -f https://raw.githubusercontent.com/mspnp/reference-architectures/master/aks/secure-baseline/workload/aspnetapp.yaml
 ```
 
 Now the ASPNET Core webapp sample is all setup. Wait until is ready to process requests running:

--- a/aks/README.md
+++ b/aks/README.md
@@ -10,7 +10,7 @@
    ```
 4. query the BU 0001's Azure Application Gateway Public Ip FQDN
    ``` bash
-   export APP_GATEWAY_PUBLIC_IP_FQDN=$(az group deployment show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.appGatewayPublicIpFqdn.value -o tsv)
+   export APP_GATEWAY_PUBLIC_IP_FQDN=$(az deployment group show --resource-group rg-enterprise-networking-spokes -n spoke-BU0001A0008 --query properties.outputs.appGatewayPublicIpFqdn.value -o tsv)
    ```
 
 ### Manually deploy a basic workload

--- a/aks/README.md
+++ b/aks/README.md
@@ -1,3 +1,10 @@
+### Prequisites
+
+> Note: execute the following prequisite steps from VSCode for a better experience
+
+1. provision [a regional hub and a spoke virtual networks](./secure-baseline/networking/network-deploy.azcli)
+2. create [the BU 0001's app team secure AKS cluster (ID: A0008)](./secure-baseline/network-deploy.azcli)
+
 ### Deploy a basic workload
 
 The following example creates the ASPNET Core Docker sample web app and an Ingress object to route to its service.

--- a/aks/README.md
+++ b/aks/README.md
@@ -4,6 +4,10 @@
 
 1. provision [a regional hub and a spoke virtual networks](./secure-baseline/networking/network-deploy.azcli)
 2. create [the BU 0001's app team secure AKS cluster (ID: A0008)](./secure-baseline/network-deploy.azcli)
+3. query the BU 0001's Azure Application Gateway Public Ip FQDN
+   ``` bash
+   export APP_GATEWAY_PUBLIC_IP_FQDN=$(az group deployment show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.appGatewayPublicIpFqdn.value -o tsv)
+   ```
 
 ### Deploy a basic workload
 
@@ -28,4 +32,4 @@ kubectl wait --namespace a0008 \
 
 Test the web app
 
-> open a browser and navigate to http://<APP_GATEWAY_PUBLIC_IP>
+> open a browser and navigate to http://{APP_GATEWAY_PUBLIC_IP_FQDN}

--- a/aks/README.md
+++ b/aks/README.md
@@ -1,0 +1,21 @@
+### Deploy a basic workload
+
+The following example creates the ASPNET Core Docker sample web app and an Ingress object to route to its service.
+
+```bash
+# Apply the contents
+kubectl apply -f https://github.com/mspnp/reference-architectures/tree/fcp/aks-baseline/aks/secure-baseline/workload/aspnetapp.yaml
+```
+
+Now the ASPNET Core webapp sample is all setup. Wait until is ready to process requests running:
+
+```bash
+kubectl wait --namespace default \
+  --for=condition=ready pod \
+  --selector=app=aspnetapp \
+  --timeout=90s
+```
+
+Test the web app
+
+> open a browser and navigate to http://<APP_GATEWAY_PUBLIC_IP>

--- a/aks/README.md
+++ b/aks/README.md
@@ -4,7 +4,11 @@
 
 1. provision [a regional hub and spoke virtual networks](./secure-baseline/networking/network-deploy.azcli)
 2. create [the BU 0001's app team secure AKS cluster (ID: A0008)](./secure-baseline/network-deploy.azcli)
-3. query the BU 0001's Azure Application Gateway Public Ip FQDN
+3. download the AKS credentails
+   ``` bash
+   az aks get-credentials -g rg-bu0001a0008 -n <cluster-name> --admin
+   ```
+4. query the BU 0001's Azure Application Gateway Public Ip FQDN
    ``` bash
    export APP_GATEWAY_PUBLIC_IP_FQDN=$(az group deployment show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.appGatewayPublicIpFqdn.value -o tsv)
    ```

--- a/aks/README.md
+++ b/aks/README.md
@@ -1,15 +1,15 @@
 ### Prequisites
 
-> Note: execute the following prequisite steps from VSCode for a better experience
+> Note: execute the prequisite steps 1 and 2 from VSCode for a better experience
 
-1. provision [a regional hub and a spoke virtual networks](./secure-baseline/networking/network-deploy.azcli)
+1. provision [a regional hub and spoke virtual networks](./secure-baseline/networking/network-deploy.azcli)
 2. create [the BU 0001's app team secure AKS cluster (ID: A0008)](./secure-baseline/network-deploy.azcli)
 3. query the BU 0001's Azure Application Gateway Public Ip FQDN
    ``` bash
    export APP_GATEWAY_PUBLIC_IP_FQDN=$(az group deployment show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.appGatewayPublicIpFqdn.value -o tsv)
    ```
 
-### Deploy a basic workload
+### Manually deploy a basic workload
 
 The following example creates the ASPNET Core Docker sample web app and an Ingress object to route to its service.
 
@@ -32,4 +32,8 @@ kubectl wait --namespace a0008 \
 
 Test the web app
 
-> open a browser and navigate to http://{APP_GATEWAY_PUBLIC_IP_FQDN}
+```bash
+curl http://${APP_GATEWAY_PUBLIC_IP_FQDN}
+```
+
+> Note: alternatively open a browser and navite to http://${APP_GATEWAY_PUBLIC_IP_FQDN}

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -519,6 +519,10 @@
         "aksClusterName": {
             "type": "string",
             "value": "[variables('clusterName')]"
+        },
+		"appGatewayPublicIpFqdn": {
+           "value": "[reference(resourceId(subscription().subscriptionId,variables('vNetResourceGroup'),'Microsoft.Network/publicIpAddresses','pip-BU0001A0008-00')).dnsSettings.fqdn]",
+           "type": "string"
         }
     }
 }

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -519,10 +519,6 @@
         "aksClusterName": {
             "type": "string",
             "value": "[variables('clusterName')]"
-        },
-		"appGatewayPublicIpFqdn": {
-           "value": "[reference(resourceId(subscription().subscriptionId,variables('vNetResourceGroup'),'Microsoft.Network/publicIpAddresses','pip-BU0001A0008-00')).dnsSettings.fqdn]",
-           "type": "string"
         }
     }
 }

--- a/aks/secure-baseline/networking/spoke-BU0001A0008.json
+++ b/aks/secure-baseline/networking/spoke-BU0001A0008.json
@@ -180,7 +180,10 @@
             "properties": {
                 "publicIPAllocationMethod": "Static",
                 "idleTimeoutInMinutes": 4,
-                "publicIPAddressVersion": "IPv4"
+                "publicIPAddressVersion": "IPv4",
+                "dnsSettings": {
+                    "domainNameLabel": "[toLower(concat(variables('orgAppId'), '00'))]"
+                }
             }
         }
     ],
@@ -196,6 +199,10 @@
         "vnetGatewaySubnetResourceIds": {
             "value": "[createArray(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('clusterVNetName'), 'snet-applicationgateways'))]",
             "type": "array"
+        },
+        "appGatewayPublicIpFqdn": {
+            "value": "[reference(resourceId('Microsoft.Network/publicIpAddresses',concat('pip-', variables('orgAppId'), '-00'))).dnsSettings.fqdn]",
+            "type": "string"
         }
     }
 }

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -23,6 +23,9 @@ spec:
       containers:
       - name: aspnetcore-webapp-sample
         image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        env:
+        - name: ASPNETCORE_URLS
+          value: "http://*:8080"
 ---
 kind: Service
 apiVersion: v1
@@ -35,6 +38,7 @@ spec:
   ports:
   - name: http
     port: 80
+    targetPort: 8080
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
       - name: aspnetcore-webapp-sample
         image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -29,9 +29,13 @@ spec:
         image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         env:
         - name: ASPNETCORE_URLS
           value: "http://*:8080"
+        - name: COMPlus_EnableDiagnostics
+          # https://github.com/dotnet/dotnet-docker/issues/940
+          value: "0"
       nodeSelector:
        agentpool: npuser01
 ---

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -1,0 +1,40 @@
+#  ------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation.  All rights reserved.
+#   Licensed under the MIT License (MIT). See License.txt in the repo root #  for license information.
+#  ------------------------------------------------------------
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: aspnetapp
+  labels:
+    app: aspnetapp
+spec:
+  containers:
+  - name: aspnetcore-webapp-sample
+    image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: aspnetapp-service
+spec:
+  selector:
+    app: aspnetapp
+  ports:
+  - name: http
+    port: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: aspnetapp-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: aspnetapp-service
+          servicePort: http
+---

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app: aspnetapp
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
       containers:
       - name: aspnetcore-webapp-sample
         image: mcr.microsoft.com/dotnet/core/samples:aspnetapp

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsUser: 1000
+        runAsUser: 10001
         runAsGroup: 3000
       containers:
       - name: aspnetcore-webapp-sample

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -29,6 +29,8 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: "http://*:8080"
+      nodeSelector:
+       agentpool: npuser01
 ---
 kind: Service
 apiVersion: v1

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -31,6 +31,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
         - name: ASPNETCORE_URLS
           value: "http://*:8080"

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -7,6 +7,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: aspnetapp
+  namespace: a0008
   labels:
     app: aspnetapp
 spec:
@@ -18,6 +19,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: aspnetapp-service
+  namespace: a0008
 spec:
   selector:
     app: aspnetapp

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: aspnetapp
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 1000
         runAsGroup: 3000

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -3,17 +3,26 @@
 #   Licensed under the MIT License (MIT). See License.txt in the repo root #  for license information.
 #  ------------------------------------------------------------
 
-kind: Pod
-apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: aspnetapp
+  name: aspnetapp-deployment
   namespace: a0008
   labels:
     app: aspnetapp
 spec:
-  containers:
-  - name: aspnetcore-webapp-sample
-    image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+  replicas: 2
+  selector:
+    matchLabels:
+      app: aspnetapp
+  template:
+    metadata:
+      labels:
+        app: aspnetapp
+    spec:
+      containers:
+      - name: aspnetcore-webapp-sample
+        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
 ---
 kind: Service
 apiVersion: v1

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -43,6 +43,16 @@ spec:
       nodeSelector:
        agentpool: npuser01
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: aspnetapp-pdb
+spec:
+  minAvailable: 75%
+  selector:
+    matchLabels:
+      app: aspnetapp
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -29,7 +29,14 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: aspnetapp-ingress
+  namespace: a0008
+  annotations:
+    # defines controller implementing this ingress resource: https://docs.microsoft.com/en-us/azure/dev-spaces/how-to/ingress-https-traefik
+    # ingress.class annotation is being deprecated in Kubernetes 1.18: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+    # For backwards compatibility, when this annotation is set, precedence is given over the new field ingressClassName under spec.
+    kubernetes.io/ingress.class: traefik
 spec:
+  # ingressClassName: "traefik"
   rules:
   - http:
       paths:

--- a/aks/workload/aspnetapp.yaml
+++ b/aks/workload/aspnetapp.yaml
@@ -27,6 +27,8 @@ spec:
       containers:
       - name: aspnetcore-webapp-sample
         image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        securityContext:
+          allowPrivilegeEscalation: false
         env:
         - name: ASPNETCORE_URLS
           value: "http://*:8080"


### PR DESCRIPTION
- add k8s manifest file for basic workload in secure baseline
- define traefik as the controller fulfilling the Ingress resource 
- add manual deployment instructions and pre-reqs
- namespace the workload 
- enforce pod scheduling in the user nodepool
- configure app gw pip dns settings as `bu0001a000800.eastus2.cloudapp.azure.com`


