### PR TITLE
Final Simplification for #289

### DIFF
--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -45,7 +45,7 @@ export SQLADMINPASSWORD
 Download `rundeployment.sh` from this repo and execute it.
 
 ```bash
-wget ${DEPLOYMENT}/rundeployment.sh
+wget ${DEPLOYMENT}rundeployment.sh
 chmod +x rundeployment.sh
 ./rundeployment.sh
 ```

--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -42,7 +42,7 @@ read -s SQLADMINPASSWORD
 export SQLADMINPASSWORD
 ```
 
-Download `rundeployment.sh` from this repo and execute it.
+Download `rundeployment.sh` from this repo and execute it. This will take about 20 minutes to execute.
 
 ```bash
 wget ${DEPLOYMENT}rundeployment.sh
@@ -50,7 +50,7 @@ chmod +x rundeployment.sh
 ./rundeployment.sh
 ```
 
-At this point you have all of the Azure resources in place: SQL Database, Cosmos DB, App Service, and Azure Storage.  There is no content in Cosmos DB nor is the web application code itself yet deployed.
+At this point you have all of the Azure resources in place: SQL Database, Cosmos DB, App Service, Application Insights, Azure Cache for Redis, Azure Front Door, Azure Service Bus, and Azure Storage.  There is no content in Cosmos DB nor is the web application code itself yet deployed.
 
 ## Populate Cosmos DB Starter Content (Optional)
 
@@ -67,7 +67,7 @@ echo $imageUrl
 
 Using the Azure Portal, Azure CLI, or Azure Storage Explorer add this document to the `cacheContainer` container in the Cosmos DB Server created above.
 
-To do this from the Azure Portal, in the resource group of deployment  click on **Azure Cosmos Db Account** then select **cacheContainer** then click on **Documents**. Click on **New Document**. Replace the whole json payload with above content and click **Save**.
+To do this from the Azure Portal, in the resource group of deployment, click on **Azure Cosmos Db Account** then select **cacheContainer** then click on **Documents**. Click on **New Document**. Replace the whole json payload with above content and click **Save**.
 
 ## Publish Web Application and Azure Function
 

--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -56,7 +56,7 @@ echo ${DEPLOYMENT}Microsoft_Azure_logo_small.png
 Using the Azure Portal or Azure Storage Explorer add this document to the `cacheContainer` container in the Cosmos DB Server created above.
 
 ```json
-{"id": "1","Message": "Powered by Azure","MessageType": "AD","Url": "[theResultFromAbove]"}
+{"id": "1","Message": "Powered by Azure","MessageType": "AD","Url": "[the full url from prior echo statement]"}
 ```
 
 To do this from the Azure Portal, in the resource group of deployment, click on **Azure Cosmos Db Account** then select **cacheContainer** in **Data Explorer**.  Click on **Items** and then **New Item**. Replace the whole json payload with above content and click **Save**.

--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -54,18 +54,17 @@ At this point you have all of the Azure resources in place: SQL Database, Cosmos
 
 ## Populate Cosmos DB Starter Content (Optional)
 
-The Cosmos DB server you deployed has a container named `cacheContainer` that is designed to hold advertisements for the website's footer. While they are not required for the Reference Implementation to function here is an example of content you could include. The script you ran above dropped a **Microsoft_Azure_logo_small.png** file into the storage account. We can reference that file in a fake ad.
+The Cosmos DB server you deployed has a container named `cacheContainer` that is designed to hold advertisements for the website's footer. While they are not required for the Reference Implementation to function here is an example of content you could include. The script you ran above dropped a **Microsoft_Azure_logo_small.png** file into the storage account. We can reference that file in a fake ad. The script above created the environment variable called `exampleAdImageUrl` that contains the URL to this image.
 
 ```bash
-imageUrl=`az storage account show -n ${STORAGEACCNAME} | jq -r .primaryEndpoints.blob`rsrcontainer/Microsoft_Azure_logo_small.png
-echo $imageUrl
+echo $exampleAdImageUrl
 ```
 
 ```json
 {"id": "1","Message": "Powered by Azure","MessageType": "AD","Url": "[yourImageUrlHere]"}
 ```
 
-Using the Azure Portal, Azure CLI, or Azure Storage Explorer add this document to the `cacheContainer` container in the Cosmos DB Server created above.
+Using the Azure Portal or Azure Storage Explorer add this document to the `cacheContainer` container in the Cosmos DB Server created above.
 
 To do this from the Azure Portal, in the resource group of deployment, click on **Azure Cosmos Db Account** then select **cacheContainer** then click on **Documents**. Click on **New Document**. Replace the whole json payload with above content and click **Save**.
 
@@ -84,3 +83,11 @@ We'll publish the web applications directly from Visual Studio. As with the reso
    1. Right click on **VoteCounter** project. Click on **Publish**, select **new profile** then click on **existing**. Select the same resource group as above. Select the function app service deployment.
 
 Your website is fully deployed now. You can open the url <https://yourwebfrontend.yourlocation.cloudapp.azure.com/>, ignoring the certificate validation error on the browser.
+
+## Clean Up Resources
+
+All resources were created in the resource group you identified in `RGNAME`. To delete everything deployed with these steps you can execute the following _destructive_ command. This will take about five minutes.
+
+```bash
+az group delete -n ${RGNAME}
+```

--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -10,6 +10,7 @@ The provided `rundeployment.sh` will create all dependencies necessary for the w
 mkdir deployweb
 cd deployweb
 
+export DEPLOYMENT=https://raw.githubusercontent.com/mspnp/reference-architectures/master/web-app/deployment/
 export RGNAME=[yourResourceGroupName]
 export RGLOCATION=[yourAzureRegionIdentifier]
 export SQLSERVERNAME=[yourSqlServerName]
@@ -44,7 +45,7 @@ export SQLADMINPASSWORD
 Download `rundeployment.sh` from this repo and execute it.
 
 ```bash
-wget https://raw.githubusercontent.com/mspnp/reference-architectures/master/web-app/deployment/rundeployment.sh
+wget ${DEPLOYMENT}/rundeployment.sh
 chmod +x rundeployment.sh
 ./rundeployment.sh
 ```

--- a/web-app/deployment/readme.md
+++ b/web-app/deployment/readme.md
@@ -17,7 +17,6 @@ export SQLSERVERNAME=[yourSqlServerName]
 export SQLSERVERDB=[youSqlServerDb]
 export SQLADMINUSER=[yourSqlAdminUser]
 export DNSNAME=[yourGloballyUniqueDNSNameOfWebApp]
-export STORAGEACCNAME=[yourGloballyUniqueStorageAccountName]
 ```
 
 > **_NOTE:_**  The DNS Name of your web application needs to be globally unique. You can use the following command to validate that the name is unique before you run the rest of the script. If you find the name is already used, change `DNSNAME` to another value.
@@ -29,13 +28,7 @@ token=`az account get-access-token -o tsv --query accessToken`
 curl -H "Authorization: Bearer ${token}" "https://management.azure.com/subscriptions/${subscription}/providers/Microsoft.Network/locations/${RGLOCATION}/CheckDnsNameAvailability?domainNameLabel=${DNSNAME}&api-version=2018-11-01"
 ```
 
-> **_NOTE:_**  The Storage Account Name of your web application needs to be globally unique. You can use the following command to validate that the name is unique before you run the rest of the script. If you find the name is already used, change `STORAGEACCNAME` to another value.
-
-```bash
-az storage account check-name -n ${STORAGEACCNAME}
-```
-
-SQL Database accounts (including the admin) have a minimum password size of eight characters ([amongst other requirements](https://docs.microsoft.com/sql/relational-databases/security/password-policy?view=azuresqldb-current)). Capture a suitable password into `SQLADMINPASSWORD`.
+SQL Database accounts (including the admin) have a minimum password size of eight characters ([amongst other requirements](https://docs.microsoft.com/sql/relational-databases/security/password-policy?view=azuresqldb-current)). Capture a suitable password into `SQLADMINPASSWORD` using the command sequence below.
 
 ```bash
 read -s SQLADMINPASSWORD
@@ -50,23 +43,23 @@ chmod +x rundeployment.sh
 ./rundeployment.sh
 ```
 
-At this point you have all of the Azure resources in place: SQL Database, Cosmos DB, App Service, Application Insights, Azure Cache for Redis, Azure Front Door, Azure Service Bus, and Azure Storage.  There is no content in Cosmos DB nor is the web application code itself yet deployed.
+At this point you have all of the Azure resources in place: SQL Database, Cosmos DB, App Service, Application Insights, Azure Cache for Redis, Azure Front Door, Azure Service Bus, and Azure Storage.  There is no AD content in Cosmos DB nor is the web application code itself yet deployed.
 
 ## Populate Cosmos DB Starter Content (Optional)
 
-The Cosmos DB server you deployed has a container named `cacheContainer` that is designed to hold advertisements for the website's footer. While they are not required for the Reference Implementation to function here is an example of content you could include. The script you ran above dropped a **Microsoft_Azure_logo_small.png** file into the storage account. We can reference that file in a fake ad. The script above created the environment variable called `exampleAdImageUrl` that contains the URL to this image.
+The Cosmos DB server you deployed has a container named `cacheContainer` that is designed to hold advertisements for the website's footer. While they are not required for the Reference Implementation to function here is an example of content you could include. We provide a file called **Microsoft_Azure_logo_small.png** in this repo. You can reference that file in a fake ad.
 
 ```bash
-echo $exampleAdImageUrl
-```
-
-```json
-{"id": "1","Message": "Powered by Azure","MessageType": "AD","Url": "[yourImageUrlHere]"}
+echo ${DEPLOYMENT}Microsoft_Azure_logo_small.png
 ```
 
 Using the Azure Portal or Azure Storage Explorer add this document to the `cacheContainer` container in the Cosmos DB Server created above.
 
-To do this from the Azure Portal, in the resource group of deployment, click on **Azure Cosmos Db Account** then select **cacheContainer** then click on **Documents**. Click on **New Document**. Replace the whole json payload with above content and click **Save**.
+```json
+{"id": "1","Message": "Powered by Azure","MessageType": "AD","Url": "[theResultFromAbove]"}
+```
+
+To do this from the Azure Portal, in the resource group of deployment, click on **Azure Cosmos Db Account** then select **cacheContainer** in **Data Explorer**.  Click on **Items** and then **New Item**. Replace the whole json payload with above content and click **Save**.
 
 ## Publish Web Application and Azure Function
 

--- a/web-app/deployment/rundeployment.sh
+++ b/web-app/deployment/rundeployment.sh
@@ -11,10 +11,10 @@ az storage container create -n rsrcontainer --account-name ${STORAGEACCNAME} --p
 wget ${DEPLOYMENT}Microsoft_Azure_logo_small.png
 
 # Uploads image public container
-az storage blob upload -c rsrcontainer -f Microsoft_Azure_logo_small.png -n Microsoft_Azure_logo_small.png --account-name ${STORAGEACCNAME}
+az storage blob upload -c rsrcontainer -f Microsoft_Azure_logo_small.png -n Microsoft_Azure_logo_small.png --account-name ${STORAGEACCNAME} --auth-mode key 
 
-# Grab the full URL to the image uplaoded 
-resourceurl=`az storage account show -n ${STORAGEACCNAME} | jq -r .primaryEndpoints.blob`rsrcontainer/Microsoft_Azure_logo_small.png
+# Grab the full URL to the image uploaded
+exampleAdImageUrl=`az storage account show -n ${STORAGEACCNAME} | jq -r .primaryEndpoints.blob`rsrcontainer/Microsoft_Azure_logo_small.png
 
 # Creates the SQL Database Server and Database with the provided admin details
 az sql server create -l "${RGLOCATION}" -g ${RGNAME} -n ${SQLSERVERNAME}  -u ${SQLADMINUSER} -p ${SQLADMINPASSWORD}
@@ -37,5 +37,5 @@ az deployment group create --resource-group ${RGNAME} --template-uri ${DEPLOYMEN
 
 # Create the CosmosDB Database and Container
 cosmosacc=`az cosmosdb list -g ${RGNAME} | jq -r .[0].name`
-az cosmosdb database create -d cacheDB -n ${cosmosacc} -g ${RGNAME}
-az cosmosdb collection create --name ${cosmosacc} -c cacheContainer -g ${RGNAME} --db-name cacheDB --partition-key-path '/MessageType'
+az cosmosdb sql database create -a ${cosmosacc} -g ${RGNAME} -n cacheDB
+az cosmosdb sql container create -a ${cosmosacc} -g ${RGNAME} -d cacheDB -p '/MessageType' -n cacheContainer

--- a/web-app/deployment/rundeployment.sh
+++ b/web-app/deployment/rundeployment.sh
@@ -3,39 +3,28 @@
 # Creates the resource group that will contain all of our application resources
 az group create --name "${RGNAME}" --location "${RGLOCATION}"
 
-# Creates the storage account and public container for the example AD image used by application
-az storage account create -n ${STORAGEACCNAME} -g ${RGNAME} -l ${RGLOCATION} --sku standard_LRS
-az storage container create -n rsrcontainer --account-name ${STORAGEACCNAME} --public-access blob
-
-# Download the sample AD image
-wget ${DEPLOYMENT}Microsoft_Azure_logo_small.png
-
-# Uploads image public container
-az storage blob upload -c rsrcontainer -f Microsoft_Azure_logo_small.png -n Microsoft_Azure_logo_small.png --account-name ${STORAGEACCNAME} --auth-mode key 
-
-# Grab the full URL to the image uploaded
-exampleAdImageUrl=`az storage account show -n ${STORAGEACCNAME} | jq -r .primaryEndpoints.blob`rsrcontainer/Microsoft_Azure_logo_small.png
-
 # Creates the SQL Database Server and Database with the provided admin details
+# This is not created in the ARM template below because it's assumed that the lifecycle
+# of this SQL Database is longer than that of this web application
 az sql server create -l "${RGLOCATION}" -g ${RGNAME} -n ${SQLSERVERNAME}  -u ${SQLADMINUSER} -p ${SQLADMINPASSWORD}
 az sql db create -s ${SQLSERVERNAME} -n ${SQLSERVERDB} -g ${RGNAME}
 
-# Set the firewall to allow ALL connections
+# Set the firewall to allow ALL connections (This would actually be set to just your web app)
 az sql server firewall-rule create -g $RGNAME -s $SQLSERVERNAME  -n azureservices --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
 
-# Populate the schema in the database
+# Populate the schema in the database (This would normally be handled via your DB Schema management solution)
 connstring=`az sql db show-connection-string --server $SQLSERVERNAME --name $SQLSERVERDB --client ado.net`
 connstring=$(echo ${connstring} | sed "s/<username>/${SQLADMINUSER}/g")
 connstring=$(echo ${connstring} | sed "s/<password>/${SQLADMINPASSWORD}/g")
 sqlcon="${connstring%\"}"
 sqlcon="${sqlcon#\"}"
-
 sqlcmd -S tcp:${SQLSERVERNAME}.database.windows.net,1433 -d ${SQLSERVERDB} -U ${SQLADMINUSER} -P ${SQLADMINPASSWORD} -N -l 30 -Q "CREATE TABLE Counts(ID INT NOT NULL IDENTITY PRIMARY KEY, Candidate VARCHAR(32) NOT NULL, Count INT)"
 
-# Deploy those resources found in the ARM template
+# Deploy those resources found in the ARM template - This deploys the bulk of the resources.
 az deployment group create --resource-group ${RGNAME} --template-uri ${DEPLOYMENT}webappdeploy.json --parameters VotingWeb_name=${DNSNAME} SqlConnectionString="$sqlcon"
 
 # Create the CosmosDB Database and Container
+# This could have been deployed as part of the ARM template above, but we opted to show AZ CLI usage here instead.
 cosmosacc=`az cosmosdb list -g ${RGNAME} | jq -r .[0].name`
 az cosmosdb sql database create -a ${cosmosacc} -g ${RGNAME} -n cacheDB
 az cosmosdb sql container create -a ${cosmosacc} -g ${RGNAME} -d cacheDB -p '/MessageType' -n cacheContainer

--- a/web-app/deployment/rundeployment.sh
+++ b/web-app/deployment/rundeployment.sh
@@ -1,52 +1,41 @@
 #!/usr/bin/env bash
 
-
-# Creates the resource group
-
+# Creates the resource group that will contain all of our application resources
 az group create --name "${RGNAME}" --location "${RGLOCATION}"
 
-# Creates the storage account for the resource used by application
+# Creates the storage account and public container for the example AD image used by application
 az storage account create -n ${STORAGEACCNAME} -g ${RGNAME} -l ${RGLOCATION} --sku standard_LRS
+az storage container create -n rsrcontainer --account-name ${STORAGEACCNAME} --public-access blob
 
-az storage container create -n rsrcontainer  --account-name ${STORAGEACCNAME} --public-access blob
-
+# Download the sample AD image
 wget ${DEPLOYMENT}Microsoft_Azure_logo_small.png
 
-# Uploads the resource to the blob container
+# Uploads image public container
 az storage blob upload -c rsrcontainer -f Microsoft_Azure_logo_small.png -n Microsoft_Azure_logo_small.png --account-name ${STORAGEACCNAME}
 
-# it stores the endpoint to the resource 
+# Grab the full URL to the image uplaoded 
 resourceurl=`az storage account show -n ${STORAGEACCNAME} | jq -r .primaryEndpoints.blob`rsrcontainer/Microsoft_Azure_logo_small.png
 
+# Creates the SQL Database Server and Database with the provided admin details
+az sql server create -l "${RGLOCATION}" -g ${RGNAME} -n ${SQLSERVERNAME}  -u ${SQLADMINUSER} -p ${SQLADMINPASSWORD}
+az sql db create -s ${SQLSERVERNAME} -n ${SQLSERVERDB} -g ${RGNAME}
 
+# Set the firewall to allow ALL connections
+az sql server firewall-rule create -g $RGNAME -s $SQLSERVERNAME  -n azureservices --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
 
-# It creates the sql server and sql database with admin user being created
-az sql server create -l "${RGLOCATION}"  -g $RGNAME -n $SQLSERVERNAME  -u $SQLADMINUSER -p $SQLADMINPASSWORD
-
-az sql db create -s $SQLSERVERNAME -n $SQLSERVERDB -g $RGNAME
-
-# it stores the connection string to be passed to arm template
-
+# Populate the schema in the database
 connstring=`az sql db show-connection-string --server $SQLSERVERNAME --name $SQLSERVERDB --client ado.net`
-
-connstring=$(echo $connstring | sed "s/<username>/${SQLADMINUSER}/g")
-connstring=$(echo $connstring | sed "s/<password>/${SQLADMINPASSWORD}/g")
+connstring=$(echo ${connstring} | sed "s/<username>/${SQLADMINUSER}/g")
+connstring=$(echo ${connstring} | sed "s/<password>/${SQLADMINPASSWORD}/g")
 sqlcon="${connstring%\"}"
 sqlcon="${sqlcon#\"}"
 
+sqlcmd -S tcp:${SQLSERVERNAME}.database.windows.net,1433 -d ${SQLSERVERDB} -U ${SQLADMINUSER} -P ${SQLADMINPASSWORD} -N -l 30 -Q "CREATE TABLE Counts(ID INT NOT NULL IDENTITY PRIMARY KEY, Candidate VARCHAR(32) NOT NULL, Count INT)"
 
-az sql server firewall-rule create -g $RGNAME -s $SQLSERVERNAME  -n azureservices --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+# Deploy those resources found in the ARM template
+az deployment group create --resource-group ${RGNAME} --template-uri ${DEPLOYMENT}webappdeploy.json --parameters VotingWeb_name=${DNSNAME} SqlConnectionString="$sqlcon"
 
-# it creates the tables in the database
-
-sqlcmd -S tcp:${SQLSERVERNAME}.database.windows.net,1433 -d $SQLSERVERDB -U $SQLADMINUSER -P $SQLADMINPASSWORD -N -l 30 -Q "CREATE TABLE Counts(ID INT NOT NULL IDENTITY PRIMARY KEY, Candidate VARCHAR(32) NOT NULL, Count INT)"
-
-# it runs the arm template deployment passing the dns name of gateway
-# the certificate and its password 
-az group deployment create --resource-group $RGNAME --template-uri ${DEPLOYMENT}webappdeploy.json --parameters VotingWeb_name=${DNSNAME} SqlConnectionString="$sqlcon" 
-
+# Create the CosmosDB Database and Container
 cosmosacc=`az cosmosdb list -g ${RGNAME} | jq -r .[0].name`
-
 az cosmosdb database create -d cacheDB -n ${cosmosacc} -g ${RGNAME}
-
 az cosmosdb collection create --name ${cosmosacc} -c cacheContainer -g ${RGNAME} --db-name cacheDB --partition-key-path '/MessageType'

--- a/web-app/deployment/webappdeploy.json
+++ b/web-app/deployment/webappdeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "VotingApi_name": {
@@ -67,12 +67,10 @@
       "type": "securestring"
     }
   },
-
   "variables": {
     "location": "[resourceGroup().location]"
   },
   "resources": [
-
     {
       "type": "Microsoft.Cache/Redis",
       "apiVersion": "2017-10-01",
@@ -90,7 +88,6 @@
         }
       }
     },
-
     {
       "type": "Microsoft.DocumentDB/databaseAccounts",
       "apiVersion": "2015-04-08",
@@ -132,9 +129,7 @@
       },
       "kind": "web",
       "properties": {
-        "Application_Type": "web",
-        "Flow_Type": "Redfield",
-        "Request_Source": "AppServiceEnablementCreate"
+        "Application_Type": "web"
       }
     },
     {
@@ -144,9 +139,7 @@
       "location": "[variables('location')]",
       "kind": "web",
       "properties": {
-        "Application_Type": "web",
-        "Flow_Type": "Redfield",
-        "HockeyAppId": ""
+        "Application_Type": "web"
       }
     },
     {
@@ -156,12 +149,9 @@
       "location": "[variables('location')]",
       "kind": "web",
       "properties": {
-        "Application_Type": "web",
-        "Flow_Type": "Redfield",
-        "HockeyAppId": ""
+        "Application_Type": "web"
       }
     },
-
     {
       "type": "Microsoft.ServiceBus/namespaces",
       "apiVersion": "2017-04-01",
@@ -178,7 +168,6 @@
         "status": "Active"
       }
     },
-
     {
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2018-07-01",
@@ -210,7 +199,6 @@
         }
       }
     },
-
     {
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2018-07-01",
@@ -307,7 +295,7 @@
     },
     {
       "type": "microsoft.insights/alertrules",
-      "apiVersion": "2014-04-01",
+      "apiVersion": "2016-03-01",
       "name": "[parameters('alertrules_FunctionVoteCounter_name')]",
       "location": "[variables('location')]",
       "dependsOn": [
@@ -340,7 +328,7 @@
     },
     {
       "type": "microsoft.insights/alertrules",
-      "apiVersion": "2014-04-01",
+      "apiVersion": "2016-03-01",
       "name": "[parameters('alertrules_VotingApi_name')]",
       "location": "[variables('location')]",
       "dependsOn": [
@@ -373,7 +361,7 @@
     },
     {
       "type": "microsoft.insights/alertrules",
-      "apiVersion": "2014-04-01",
+      "apiVersion": "2016-03-01",
       "name": "[parameters('alertrules_VotingWeb_name')]",
       "location": "[variables('location')]",
       "dependsOn": [
@@ -528,21 +516,16 @@
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
               "value": "[reference(resourceId('Microsoft.Insights/components', parameters('FunctionVoteCounter_name')), '2014-04-01').InstrumentationKey]"
             },
-
             {
               "name": "SERVICEBUS_CONNECTION_STRING",
               "value": "[listKeys(resourceId(concat('Microsoft.ServiceBus/namespaces/AuthorizationRules'),parameters('servicebusvotingns_name'),'RootManageSharedAccessKey'),'2015-08-01').primaryConnectionString]"
             },
-
             {
               "name": "sqldb_connection",
               "value": "[parameters('SqlConnectionString')]"
             }
-
           ]
-
         }
-
       }
     },
     {
@@ -605,24 +588,16 @@
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
               "value": "[reference(resourceId('Microsoft.Insights/components', parameters('VotingApi_name')), '2014-04-01').InstrumentationKey]"
             },
-
             {
               "name": "ApplicationInsights:InstrumentationKey",
               "value": "[reference(resourceId('Microsoft.Insights/components', parameters('VotingApi_name')), '2014-04-01').InstrumentationKey]"
             },
-
-
             {
               "name": "ConnectionStrings:SqlDbConnection",
               "value": "[parameters('SqlConnectionString')]"
             }
           ]
-
-
-
-
         }
-
       }
     },
     {
@@ -685,42 +660,34 @@
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
               "value": "[reference(resourceId('Microsoft.Insights/components', parameters('VotingWeb_name')), '2014-04-01').InstrumentationKey]"
             },
-
             {
               "name": "ConnectionStrings:sbConnectionString",
               "value": "[listKeys(resourceId(concat('Microsoft.ServiceBus/namespaces/AuthorizationRules'),parameters('servicebusvotingns_name'),'RootManageSharedAccessKey'),'2015-08-01').primaryConnectionString]"
             },
-
             {
               "name": "ConnectionStrings:VotingDataAPIBaseUri",
               "value": "[concat('https://',parameters('VotingApi_name'),'.azurewebsites.net')]"
             },
-
             {
               "name": "ApplicationInsights:InstrumentationKey",
               "value": "[reference(resourceId('Microsoft.Insights/components', parameters('VotingWeb_name')), '2014-04-01').InstrumentationKey]"
             },
-
             {
               "name": "ConnectionStrings:RedisConnectionString",
               "value": "[concat(parameters('Votingrediscache_name'),'.redis.cache.windows.net:6380,abortConnect=false,ssl=true,password=', listKeys(resourceId('Microsoft.Cache/Redis', parameters('Votingrediscache_name')), '2015-08-01').primaryKey)]"
             },
-
             {
               "name": "ConnectionStrings:queueName",
               "value": "votingqueue"
             },
-
             {
               "name": "ConnectionStrings:CosmosUri",
               "value": "[concat('https://',parameters('databaseAccounts_votingcosmos_name'),'.documents.azure.com:443/')]"
             },
-
             {
               "name": "ConnectionStrings:CosmosKey",
               "value": "[listKeys(resourceId(concat('Microsoft.DocumentDB/databaseAccounts'),parameters('databaseAccounts_votingcosmos_name')),'2015-04-08').primaryMasterKey]"
             }
-
           ]
         }
       }
@@ -825,10 +792,5 @@
       }
   }
   ],
-
-  "outputs": {
-
-
-  }
-
+  "outputs": {}
 }

--- a/web-app/deployment/webappdeploy.json
+++ b/web-app/deployment/webappdeploy.json
@@ -38,18 +38,6 @@
       "defaultValue": "[concat( 'votingcosmos-',uniqueString(resourceGroup().id) ) ]",
       "type": "string"
     },
-    "alertrules_VotingApi_name": {
-      "defaultValue": "[concat( 'failureanomalieswebapi-',uniqueString(resourceGroup().id) ) ]",
-      "type": "string"
-    },
-    "alertrules_VotingWeb_name": {
-      "defaultValue": "[concat( 'failureanomaliesweb-',uniqueString(resourceGroup().id) ) ]",
-      "type": "string"
-    },
-    "alertrules_FunctionVoteCounter_name": {
-      "defaultValue": "[concat( 'failureanomaliesfunction-',uniqueString(resourceGroup().id) ) ]",
-      "type": "string"
-    },
     "FunctionstorageAccount": {
       "defaultValue": "[toLower(concat('function', uniqueString(resourceGroup().id) )) ]",
       "type": "string"
@@ -185,7 +173,7 @@
           "ipRules": [],
           "defaultAction": "Allow"
         },
-        "supportsHttpsTrafficOnly": false,
+        "supportsHttpsTrafficOnly": true,
         "encryption": {
           "services": {
             "file": {
@@ -216,7 +204,7 @@
           "ipRules": [],
           "defaultAction": "Allow"
         },
-        "supportsHttpsTrafficOnly": false,
+        "supportsHttpsTrafficOnly": true,
         "encryption": {
           "services": {
             "file": {
@@ -291,105 +279,6 @@
         "reserved": false,
         "targetWorkerCount": 0,
         "targetWorkerSizeId": 0
-      }
-    },
-    {
-      "type": "microsoft.insights/alertrules",
-      "apiVersion": "2016-03-01",
-      "name": "[parameters('alertrules_FunctionVoteCounter_name')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[resourceId('microsoft.insights/components', parameters('FunctionVoteCounter_name'))]"
-      ],
-      "tags": {
-        "[concat('hidden-link:/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/microsoft.insights/components/',parameters('FunctionVoteCounter_name'))]": "Resource"
-      },
-      "properties": {
-        "name": "[parameters('alertrules_FunctionVoteCounter_name')]",
-        "description": "",
-        "isEnabled": true,
-        "condition": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.ThresholdRuleCondition",
-          "dataSource": {
-            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource",
-            "resourceUri": "[resourceId('microsoft.insights/components', parameters('FunctionVoteCounter_name'))]",
-            "metricName": "advanced::A3108E3D-5E26-44CF-B232-783F5E20EF10::ewAiAEgAeQBwAGUAcgBpAG8AbgBBAHAAcABsAGkAYwBhAHQAaQBvAG4AUwBpAGQAIgA6AG4AdQBsAGwALAAiAEgAeQBwAGUAcgBpAG8AbgBTAHUAYgBqAGUAYwB0AFMAaQBkACIAOgBuAHUAbABsACwAIgBIAHkAcABlAHIAaQBvAG4ATwBiAHMAZQByAHYAZQByAFMAaQBkACIAOgBuAHUAbABsACwAIgBDAHUAcwB0AG8AbQBlAHIAQQBjAGMAbwB1AG4AdABJAGQAIgA6ACIAMAAwADAAMAAwADAAMAAwAC0AMAAwADAAMAAtADAAMAAwADAALQAwADAAMAAwAC0AMAAwADAAMAAwADAAMAAwADAAMAAwADAAIgAsACIAQQBwAHAAbABpAGMAYQB0AGkAbwBuAE4AYQBtAGUAIgA6AG4AdQBsAGwALAAiAEEAcABwAGwAaQBjAGEAdABpAG8AbgBJAGQAIgA6AG4AdQBsAGwALAAiAFAAcgBvAGYAaQBsAGUASQBkACIAOgAwACwAIgBXAGkAbgBkAG8AdwBTAGkAegBlAEkAbgBNAGkAbgB1AHQAZQBzACIAOgA2ADAALAAiAE0AZQB0AHIAaQBjAE4AYQBtAGUAIgA6ACIAIgAsACIAVABoAHIAZQBzAGgAbwBsAGQAIgA6ADIALgAwACwAIgBBAGwAZQByAHQAVABlAG0AcABsAGEAdABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAE4AYQBtAGUAIgA6ACIAIgAsACIAUgB1AGwAZQBEAGUAcwBjAHIAaQBwAHQAaQBvAG4AIgA6ACIAIgAsACIAUgBlAHMAbwB1AHIAYwBlAEkAZAAiADoAbgB1AGwAbAAsACIAUwB1AGIAcwBjAHIAaQBwAHQAaQBvAG4ASQBkACIAOgBuAHUAbABsACwAIgBBAGcAZwByAGUAZwBhAHQAZQBGAHUAbgBjAHQAaQBvAG4AIgA6ACIAIgAsACIAQwBvAG0AcABhAHIAaQBzAG8AbgBPAHAAZQByAGEAdABvAHIAIgA6ACIAewBcACIAQgBhAHMAZQBsAGkAbgBlAFQAaQBtAGUAcwBwAGEAbgBcACIAOgBcACIAMAAwADoANAAwADoAMAAwAFwAIgAsAFwAIgBJAG4AcwBpAGcAaAB0AHMAUwBlAHIAdgBpAGMAZQBMAGEAZwBcACIAOgBcACIAMAAwADoAMAAwADoAMAAwAFwAIgAsAFwAIgBCAHUAZgBmAGUAcgBUAGkAbQBlAFwAIgA6AFwAIgAwADAAOgAwADEAOgAwADAAXAAiACwAXAAiAEIAbABvAGIAUwB0AG8AcgBhAGcAZQBMAG8AZwBnAGkAbgBnAEUAbgBhAGIAbABlAGQAXAAiADoAZgBhAGwAcwBlACwAXAAiAFUAcwBlAHIAUwB1AHAAcAByAGUAcwBzAGkAbwBuAHMAXAAiADoAbgB1AGwAbAAsAFwAIgBQAHIAbwBmAGkAbABlAEkAZABcACIAOgAwACwAXAAiAEUAbQBhAGkAbABUAHkAcABlAFwAIgA6ADAALABcACIAUgBkAGQARgBhAGkAbAB1AHIAZQBzAFMAcABpAGsAZQBUAGgAcgBlAHMAaABvAGwAZABcACIAOgAzAC4AMAAsAFwAIgBSAGEAdwBQAHIAbwBhAGMAdABpAHYAZQBSAHUAbABlAEMAbwBuAGYAaQBnAFwAIgA6AG4AdQBsAGwAfQAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8AQwB1AHMAdABvAG0AIgA6AGYAYQBsAHMAZQAsACIAQwB1AHMAdABvAG0ARQBtAGEAaQBsAHMARQBuAGMAbwBkAGUAZAAiADoAIgAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8ATwB3AG4AZQByAHMAIgA6AGYAYQBsAHMAZQB9AA=="
-          },
-          "operator": "GreaterThan",
-          "threshold": 2,
-          "windowSize": "PT1H"
-        },
-        "action": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleEmailAction",
-          "sendToServiceOwners": true,
-          "customEmails": []
-        }
-      }
-    },
-    {
-      "type": "microsoft.insights/alertrules",
-      "apiVersion": "2016-03-01",
-      "name": "[parameters('alertrules_VotingApi_name')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[resourceId('microsoft.insights/components', parameters('VotingApi_name'))]"
-      ],
-      "tags": {
-        "[concat('hidden-link:/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/microsoft.insights/components/',parameters('VotingApi_name'))]": "Resource"
-      },
-      "properties": {
-        "name": "[parameters('alertrules_VotingApi_name')]",
-        "description": "",
-        "isEnabled": true,
-        "condition": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.ThresholdRuleCondition",
-          "dataSource": {
-            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource",
-            "resourceUri": "[resourceId('microsoft.insights/components', parameters('VotingApi_name'))]",
-            "metricName": "advanced::A3108E3D-5E26-44CF-B232-783F5E20EF10::ewAiAEgAeQBwAGUAcgBpAG8AbgBBAHAAcABsAGkAYwBhAHQAaQBvAG4AUwBpAGQAIgA6AG4AdQBsAGwALAAiAEgAeQBwAGUAcgBpAG8AbgBTAHUAYgBqAGUAYwB0AFMAaQBkACIAOgBuAHUAbABsACwAIgBIAHkAcABlAHIAaQBvAG4ATwBiAHMAZQByAHYAZQByAFMAaQBkACIAOgBuAHUAbABsACwAIgBDAHUAcwB0AG8AbQBlAHIAQQBjAGMAbwB1AG4AdABJAGQAIgA6ACIAMAAwADAAMAAwADAAMAAwAC0AMAAwADAAMAAtADAAMAAwADAALQAwADAAMAAwAC0AMAAwADAAMAAwADAAMAAwADAAMAAwADAAIgAsACIAQQBwAHAAbABpAGMAYQB0AGkAbwBuAE4AYQBtAGUAIgA6AG4AdQBsAGwALAAiAEEAcABwAGwAaQBjAGEAdABpAG8AbgBJAGQAIgA6AG4AdQBsAGwALAAiAFAAcgBvAGYAaQBsAGUASQBkACIAOgAwACwAIgBXAGkAbgBkAG8AdwBTAGkAegBlAEkAbgBNAGkAbgB1AHQAZQBzACIAOgA2ADAALAAiAE0AZQB0AHIAaQBjAE4AYQBtAGUAIgA6ACIAIgAsACIAVABoAHIAZQBzAGgAbwBsAGQAIgA6ADIALgAwACwAIgBBAGwAZQByAHQAVABlAG0AcABsAGEAdABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAE4AYQBtAGUAIgA6ACIAIgAsACIAUgB1AGwAZQBEAGUAcwBjAHIAaQBwAHQAaQBvAG4AIgA6ACIAIgAsACIAUgBlAHMAbwB1AHIAYwBlAEkAZAAiADoAbgB1AGwAbAAsACIAUwB1AGIAcwBjAHIAaQBwAHQAaQBvAG4ASQBkACIAOgBuAHUAbABsACwAIgBBAGcAZwByAGUAZwBhAHQAZQBGAHUAbgBjAHQAaQBvAG4AIgA6ACIAIgAsACIAQwBvAG0AcABhAHIAaQBzAG8AbgBPAHAAZQByAGEAdABvAHIAIgA6ACIAewBcACIAQgBhAHMAZQBsAGkAbgBlAFQAaQBtAGUAcwBwAGEAbgBcACIAOgBcACIAMAAwADoANAAwADoAMAAwAFwAIgAsAFwAIgBJAG4AcwBpAGcAaAB0AHMAUwBlAHIAdgBpAGMAZQBMAGEAZwBcACIAOgBcACIAMAAwADoAMAAwADoAMAAwAFwAIgAsAFwAIgBCAHUAZgBmAGUAcgBUAGkAbQBlAFwAIgA6AFwAIgAwADAAOgAwADEAOgAwADAAXAAiACwAXAAiAEIAbABvAGIAUwB0AG8AcgBhAGcAZQBMAG8AZwBnAGkAbgBnAEUAbgBhAGIAbABlAGQAXAAiADoAZgBhAGwAcwBlACwAXAAiAFUAcwBlAHIAUwB1AHAAcAByAGUAcwBzAGkAbwBuAHMAXAAiADoAbgB1AGwAbAAsAFwAIgBQAHIAbwBmAGkAbABlAEkAZABcACIAOgAwACwAXAAiAEUAbQBhAGkAbABUAHkAcABlAFwAIgA6ADAALABcACIAUgBkAGQARgBhAGkAbAB1AHIAZQBzAFMAcABpAGsAZQBUAGgAcgBlAHMAaABvAGwAZABcACIAOgAzAC4AMAAsAFwAIgBSAGEAdwBQAHIAbwBhAGMAdABpAHYAZQBSAHUAbABlAEMAbwBuAGYAaQBnAFwAIgA6AG4AdQBsAGwAfQAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8AQwB1AHMAdABvAG0AIgA6AGYAYQBsAHMAZQAsACIAQwB1AHMAdABvAG0ARQBtAGEAaQBsAHMARQBuAGMAbwBkAGUAZAAiADoAIgAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8ATwB3AG4AZQByAHMAIgA6AGYAYQBsAHMAZQB9AA=="
-          },
-          "operator": "GreaterThan",
-          "threshold": 2,
-          "windowSize": "PT1H"
-        },
-        "action": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleEmailAction",
-          "sendToServiceOwners": true,
-          "customEmails": []
-        }
-      }
-    },
-    {
-      "type": "microsoft.insights/alertrules",
-      "apiVersion": "2016-03-01",
-      "name": "[parameters('alertrules_VotingWeb_name')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[resourceId('microsoft.insights/components', parameters('VotingWeb_name'))]"
-      ],
-      "tags": {
-        "[concat('hidden-link:/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/microsoft.insights/components/',parameters('VotingWeb_name'))]": "Resource"
-      },
-      "properties": {
-        "name": "[parameters('alertrules_VotingWeb_name')]",
-        "description": "",
-        "isEnabled": true,
-        "condition": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.ThresholdRuleCondition",
-          "dataSource": {
-            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource",
-            "resourceUri": "[resourceId('microsoft.insights/components', parameters('VotingWeb_name'))]",
-            "metricName": "advanced::A3108E3D-5E26-44CF-B232-783F5E20EF10::ewAiAEgAeQBwAGUAcgBpAG8AbgBBAHAAcABsAGkAYwBhAHQAaQBvAG4AUwBpAGQAIgA6AG4AdQBsAGwALAAiAEgAeQBwAGUAcgBpAG8AbgBTAHUAYgBqAGUAYwB0AFMAaQBkACIAOgBuAHUAbABsACwAIgBIAHkAcABlAHIAaQBvAG4ATwBiAHMAZQByAHYAZQByAFMAaQBkACIAOgBuAHUAbABsACwAIgBDAHUAcwB0AG8AbQBlAHIAQQBjAGMAbwB1AG4AdABJAGQAIgA6ACIAMAAwADAAMAAwADAAMAAwAC0AMAAwADAAMAAtADAAMAAwADAALQAwADAAMAAwAC0AMAAwADAAMAAwADAAMAAwADAAMAAwADAAIgAsACIAQQBwAHAAbABpAGMAYQB0AGkAbwBuAE4AYQBtAGUAIgA6AG4AdQBsAGwALAAiAEEAcABwAGwAaQBjAGEAdABpAG8AbgBJAGQAIgA6AG4AdQBsAGwALAAiAFAAcgBvAGYAaQBsAGUASQBkACIAOgAwACwAIgBXAGkAbgBkAG8AdwBTAGkAegBlAEkAbgBNAGkAbgB1AHQAZQBzACIAOgA2ADAALAAiAE0AZQB0AHIAaQBjAE4AYQBtAGUAIgA6ACIAIgAsACIAVABoAHIAZQBzAGgAbwBsAGQAIgA6ADIALgAwACwAIgBBAGwAZQByAHQAVABlAG0AcABsAGEAdABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAEkAZAAiADoAIgAiACwAIgBSAHUAbABlAE4AYQBtAGUAIgA6ACIAIgAsACIAUgB1AGwAZQBEAGUAcwBjAHIAaQBwAHQAaQBvAG4AIgA6ACIAIgAsACIAUgBlAHMAbwB1AHIAYwBlAEkAZAAiADoAbgB1AGwAbAAsACIAUwB1AGIAcwBjAHIAaQBwAHQAaQBvAG4ASQBkACIAOgBuAHUAbABsACwAIgBBAGcAZwByAGUAZwBhAHQAZQBGAHUAbgBjAHQAaQBvAG4AIgA6ACIAIgAsACIAQwBvAG0AcABhAHIAaQBzAG8AbgBPAHAAZQByAGEAdABvAHIAIgA6ACIAewBcACIAQgBhAHMAZQBsAGkAbgBlAFQAaQBtAGUAcwBwAGEAbgBcACIAOgBcACIAMAAwADoANAAwADoAMAAwAFwAIgAsAFwAIgBJAG4AcwBpAGcAaAB0AHMAUwBlAHIAdgBpAGMAZQBMAGEAZwBcACIAOgBcACIAMAAwADoAMAAwADoAMAAwAFwAIgAsAFwAIgBCAHUAZgBmAGUAcgBUAGkAbQBlAFwAIgA6AFwAIgAwADAAOgAwADEAOgAwADAAXAAiACwAXAAiAEIAbABvAGIAUwB0AG8AcgBhAGcAZQBMAG8AZwBnAGkAbgBnAEUAbgBhAGIAbABlAGQAXAAiADoAZgBhAGwAcwBlACwAXAAiAFUAcwBlAHIAUwB1AHAAcAByAGUAcwBzAGkAbwBuAHMAXAAiADoAbgB1AGwAbAAsAFwAIgBQAHIAbwBmAGkAbABlAEkAZABcACIAOgAwACwAXAAiAEUAbQBhAGkAbABUAHkAcABlAFwAIgA6ADAALABcACIAUgBkAGQARgBhAGkAbAB1AHIAZQBzAFMAcABpAGsAZQBUAGgAcgBlAHMAaABvAGwAZABcACIAOgAzAC4AMAAsAFwAIgBSAGEAdwBQAHIAbwBhAGMAdABpAHYAZQBSAHUAbABlAEMAbwBuAGYAaQBnAFwAIgA6AG4AdQBsAGwAfQAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8AQwB1AHMAdABvAG0AIgA6AGYAYQBsAHMAZQAsACIAQwB1AHMAdABvAG0ARQBtAGEAaQBsAHMARQBuAGMAbwBkAGUAZAAiADoAIgAiACwAIgBFAG4AYQBiAGwAZQBTAGUAbgBkAEUAbQBhAGkAbABUAG8ATwB3AG4AZQByAHMAIgA6AGYAYQBsAHMAZQB9AA=="
-          },
-          "operator": "GreaterThan",
-          "threshold": 2,
-          "windowSize": "PT1H"
-        },
-        "action": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleEmailAction",
-          "sendToServiceOwners": true,
-          "customEmails": []
-        }
       }
     },
     {

--- a/web-app/deployment/webappdeploy.json
+++ b/web-app/deployment/webappdeploy.json
@@ -90,7 +90,8 @@
         "enableAutomaticFailover": false,
         "enableMultipleWriteLocations": true,
         "isVirtualNetworkFilterEnabled": false,
-        "virtualNetworkRules": [],
+        "virtualNetworkRules": [
+        ],
         "databaseAccountOfferType": "Standard",
         "consistencyPolicy": {
           "defaultConsistencyLevel": "Session",
@@ -103,7 +104,8 @@
             "failoverPriority": 0
           }
         ],
-        "capabilities": []
+        "capabilities": [
+        ]
       }
     },
     {
@@ -169,8 +171,10 @@
       "properties": {
         "networkAcls": {
           "bypass": "AzureServices",
-          "virtualNetworkRules": [],
-          "ipRules": [],
+          "virtualNetworkRules": [
+          ],
+          "ipRules": [
+          ],
           "defaultAction": "Allow"
         },
         "supportsHttpsTrafficOnly": true,
@@ -200,8 +204,10 @@
       "properties": {
         "networkAcls": {
           "bypass": "AzureServices",
-          "virtualNetworkRules": [],
-          "ipRules": [],
+          "virtualNetworkRules": [
+          ],
+          "ipRules": [
+          ],
           "defaultAction": "Allow"
         },
         "supportsHttpsTrafficOnly": true,
@@ -587,99 +593,98 @@
       "name": "[parameters('frontdoors_VotingFrontDoor_name')]",
       "location": "Global",
       "properties": {
-          "resourceState": "Enabled",
-          "backendPools": [
-              {
-                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/BackendPools/', parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool'))]",
-                  "name": "[concat(parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool')]",
-                  "properties": {
-                      "backends": [
-                          {
-                              "address": "[concat(parameters('VotingWeb_name'),'.azurewebsites.net')]",
-                              "httpPort": 80,
-                              "httpsPort": 443,
-                              "priority": 1,
-                              "weight": 50,
-                              "backendHostHeader": "[concat(parameters('VotingWeb_name'),'.azurewebsites.net')]",
-                              "enabledState": "Enabled"
-                          }
-                      ],
-                      "healthProbeSettings": {
-                          "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/healthProbeSettings/healthProbeSettings-1569015585276')]"
-                      },
-                      "loadBalancingSettings": {
-                          "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/loadBalancingSettings/loadBalancingSettings-1569015585276')]"
-                      },
-                      "resourceState": "Enabled"
-                  }
-              }
-          ],
-          "healthProbeSettings": [
-              {
-                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/HealthProbeSettings/healthProbeSettings-1569015585276')]",
-                  "name": "healthProbeSettings-1569015585276",
-                  "properties": {
-                      "intervalInSeconds": 30,
-                      "path": "/",
-                      "protocol": "Https",
-                      "resourceState": "Enabled"
-                  }
-              }
-          ],
-          "frontendEndpoints": [
-              {
-                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/FrontendEndpoints/', parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net'))]",
-                  "name": "[concat(parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net')]",
-                  "properties": {
-                      "hostName": "[concat(parameters('frontdoors_VotingFrontDoor_name'), '.azurefd.net')]",
-                      "sessionAffinityEnabledState": "Disabled",
-                      "sessionAffinityTtlSeconds": 0,
-                      "resourceState": "Enabled"
-                  }
-              }
-          ],
-          "loadBalancingSettings": [
-              {
-                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/LoadBalancingSettings/loadBalancingSettings-1569015585276')]",
-                  "name": "loadBalancingSettings-1569015585276",
-                  "properties": {
-                      "additionalLatencyMilliseconds": 0,
-                      "sampleSize": 4,
-                      "successfulSamplesRequired": 2,
-                      "resourceState": "Enabled"
-                  }
-              }
-          ],
-          "routingRules": [
-              {
-                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/RoutingRules/Default')]",
-                  "name": "Default",
-                  "properties": {
-                      "frontendEndpoints": [
-                          {
-                              "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/frontendEndpoints/', parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net'))]"
-                          }
-                      ],
-                      "acceptedProtocols": [
-                          "Http",
-                          "Https"
-                      ],
-                      "patternsToMatch": [
-                          "/*"
-                      ],
-                      "forwardingProtocol": "HttpsOnly",
-                      "backendPool": {
-                          "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/backendPools/', parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool'))]"
-                      },
-                      "enabledState": "Enabled",
-                      "resourceState": "Enabled"
-                  }
-              }
-          ],
-          "enabledState": "Enabled",
-          "friendlyName": "[parameters('frontdoors_VotingFrontDoor_name')]"
+        "resourceState": "Enabled",
+        "backendPools": [
+          {
+            "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/BackendPools/', parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool'))]",
+            "name": "[concat(parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool')]",
+            "properties": {
+              "backends": [
+                {
+                  "address": "[concat(parameters('VotingWeb_name'),'.azurewebsites.net')]",
+                  "httpPort": 80,
+                  "httpsPort": 443,
+                  "priority": 1,
+                  "weight": 50,
+                  "backendHostHeader": "[concat(parameters('VotingWeb_name'),'.azurewebsites.net')]",
+                  "enabledState": "Enabled"
+                }
+              ],
+              "healthProbeSettings": {
+                "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/healthProbeSettings/healthProbeSettings-1569015585276')]"
+              },
+              "loadBalancingSettings": {
+                "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/loadBalancingSettings/loadBalancingSettings-1569015585276')]"
+              },
+              "resourceState": "Enabled"
+            }
+          }
+        ],
+        "healthProbeSettings": [
+          {
+            "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/HealthProbeSettings/healthProbeSettings-1569015585276')]",
+            "name": "healthProbeSettings-1569015585276",
+            "properties": {
+              "intervalInSeconds": 30,
+              "path": "/",
+              "protocol": "Https",
+              "resourceState": "Enabled"
+            }
+          }
+        ],
+        "frontendEndpoints": [
+          {
+            "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/FrontendEndpoints/', parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net'))]",
+            "name": "[concat(parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net')]",
+            "properties": {
+              "hostName": "[concat(parameters('frontdoors_VotingFrontDoor_name'), '.azurefd.net')]",
+              "sessionAffinityEnabledState": "Disabled",
+              "sessionAffinityTtlSeconds": 0,
+              "resourceState": "Enabled"
+            }
+          }
+        ],
+        "loadBalancingSettings": [
+          {
+            "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/LoadBalancingSettings/loadBalancingSettings-1569015585276')]",
+            "name": "loadBalancingSettings-1569015585276",
+            "properties": {
+              "additionalLatencyMilliseconds": 0,
+              "sampleSize": 4,
+              "successfulSamplesRequired": 2,
+              "resourceState": "Enabled"
+            }
+          }
+        ],
+        "routingRules": [
+          {
+            "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), '/RoutingRules/Default')]",
+            "name": "Default",
+            "properties": {
+              "frontendEndpoints": [
+                {
+                  "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/frontendEndpoints/', parameters('frontdoors_VotingFrontDoor_name'), '-azurefd-net'))]"
+                }
+              ],
+              "acceptedProtocols": [
+                "Http",
+                "Https"
+              ],
+              "patternsToMatch": [
+                "/*"
+              ],
+              "forwardingProtocol": "HttpsOnly",
+              "backendPool": {
+                "id": "[concat(resourceId('Microsoft.Network/frontdoors', parameters('frontdoors_VotingFrontDoor_name')), concat('/backendPools/', parameters('frontdoors_VotingFrontDoor_name'), 'BackendPool'))]"
+              },
+              "enabledState": "Enabled",
+              "resourceState": "Enabled"
+            }
+          }
+        ],
+        "enabledState": "Enabled",
+        "friendlyName": "[parameters('frontdoors_VotingFrontDoor_name')]"
       }
-  }
-  ],
-  "outputs": {}
+    }
+  ]
 }


### PR DESCRIPTION
* Remove legacy Application Insights alerts (these are now captured in the default smart alerts)
* Move to the non-deprecated az cli commands for Cosmos DB
* Remove the extranous storage account for the image, they can reference it directly from the repo here.  That simplifies the story/resources and achieves the same result.  Also removes some unnecssary resource creation.
* Reintroduce `${DEPLOYMENT}` (that was an accidental remove)
* Add a "Clean Up" step
* Storage should be https only

While even more could be done (like moving CosmosDB and SQL into the ARM template), I think this is enough effort put towards cleaning this up.  This will be the last PR for #289 from a deployment perspective.  I'll take a look at the "it's not working" bit after this is complete.