### PR TITLE
[FCP] [AAC-AKS] CSI integration

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -52,6 +52,11 @@ The following example creates the Ingress Controller (Traefik),
 the ASPNET Core Docker sample web app and an Ingress object to route to its service.
 
 ```bash
+# Import the *.aks-ingress.contoso.com to AzureKeyVault
+az keyvault set-policy --certificate-permissions import -n $KEYVAULT_NAME --upn $(az account show --query user.name -o tsv) && \
+cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt traefik-ingress-internal-aks-ingress-contoso-com-tls.key > traefik-ingress-internal-aks-ingress-contoso-com-tls.pem && \
+az keyvault certificate import --vault-name $KEYVAULT_NAME -f traefik-ingress-internal-aks-ingress-contoso-com-tls.pem -n traefik-ingress-internal-aks-ingress-contoso-com-tls
+
 # Ensure Flux has created the following namespace and then press Ctrl-C
 kubectl get ns a0008 -w
 

--- a/aks/secure-baseline/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
+++ b/aks/secure-baseline/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
@@ -1,0 +1,320 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azurepodidentityexceptions.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzurePodIdentityException
+    singular: azurepodidentityexception
+    plural: azurepodidentityexceptions
+  scope: Namespaced
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-identity-mic
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: mic
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-identity-nmi
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: nmi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-identity-mic
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: mic
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: [ "list", "watch" ]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "create", "update"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: [ "create", "get", "update"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list", "watch", "post", "update"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azurepodidentityexceptions"]
+  verbs: ["list", "update"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-identity-nmi
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: nmi
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities", "azurepodidentityexceptions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-identity-mic
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: mic
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-identity-mic
+  namespace: cluster-baseline-settings
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-identity-mic
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-identity-nmi
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: nmi
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-identity-nmi
+  namespace: cluster-baseline-settings
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-identity-nmi
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aad-pod-identity-nmi
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: nmi
+    tier: node
+  annotations:
+    description: Deploy components for aad-pod-identity
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aad-pod-identity
+      app.kubernetes.io/instance: aad-pod-identity
+      app.kubernetes.io/component: nmi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aad-pod-identity
+        app.kubernetes.io/instance: aad-pod-identity
+        app.kubernetes.io/component: nmi
+        tier: node
+    spec:
+      serviceAccountName: aad-pod-identity-nmi
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: iptableslock
+      containers:
+      - name: nmi
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.6.1"
+        imagePullPolicy: Always
+        args:
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+          - --operation-mode=standard
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: FORCENAMESPACED
+            value: "false"
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: iptableslock
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        agentpool: npuser01
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aad-pod-identity-mic
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: mic
+  annotations:
+    description: Deploy components for aad-pod-identity
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aad-pod-identity
+      app.kubernetes.io/instance: aad-pod-identity
+      app.kubernetes.io/component: mic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aad-pod-identity
+        app.kubernetes.io/instance: aad-pod-identity
+        app.kubernetes.io/component: mic
+    spec:
+      serviceAccountName: aad-pod-identity-mic
+      containers:
+      - name: mic
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.6.1"
+        imagePullPolicy: Always
+        args:
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        env:
+          - name: MIC_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        volumeMounts:
+          - name: certificates
+            mountPath: /etc/kubernetes/certs
+            readOnly: true
+          - name: k8s-azure-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        resources:
+            limits:
+              cpu: 200m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+      - name: certificates
+        hostPath:
+          path: /etc/kubernetes/certs
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        agentpool: npuser01

--- a/aks/secure-baseline/cluster-baseline-settings/aad-pod-identity/exceptions/aad-pod-identity-exceptions.yaml
+++ b/aks/secure-baseline/cluster-baseline-settings/aad-pod-identity/exceptions/aad-pod-identity-exceptions.yaml
@@ -1,0 +1,46 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: aad-pod-identity-mic-exception
+  namespace: cluster-baseline-settings
+spec:
+  podLabels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/component: mic
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: aks-addon-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    kubernetes.azure.com/managedby: aks
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: aks-azure-policy-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    app: azure-policy
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: oms-agent-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    component: oms-agent
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: oms-agent-rs-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    rsName: omsagent-rs

--- a/aks/secure-baseline/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/aks/secure-baseline/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -229,7 +229,7 @@ spec:
         - name: secrets-store
           image: docker.io/deislabs/secrets-store-csi:v0.0.11
           args:
-            - "--debug=true" #TODO switch to false once it is working fine
+            - "--debug=false"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"

--- a/aks/secure-baseline/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/aks/secure-baseline/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -1,0 +1,340 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secrets-store-csi-driver
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secretproviderclasses-role
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderclasses-rolebinding
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderclasses-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: cluster-baseline-settings
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+spec:
+  podInfoOnMount: true
+  attachRequired: false
+  volumeLifecycleModes:
+  - Ephemeral
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver-secretproviderclasses-crd
+    app.kubernetes.io/component: csi-driver
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClass
+    listKind: SecretProviderClassList
+    plural: secretproviderclasses
+    singular: secretproviderclass
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClass is the Schema for the secretproviderclasses
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+          properties:
+            parameters:
+              additionalProperties:
+                type: string
+              description: Configuration for specific provider
+              type: object
+            provider:
+              description: Configuration for provider name
+              type: string
+            secretObjects:
+              items:
+                description: SecretObject defines the desired state of synced K8s
+                  secret objects
+                properties:
+                  data:
+                    items:
+                      description: SecretObjectData defines the desired state of synced
+                        K8s secret object data
+                      properties:
+                        key:
+                          description: data field to populate
+                          type: string
+                        objectName:
+                          description: name of the object to sync
+                          type: string
+                      type: object
+                    type: array
+                  secretName:
+                    description: name of the K8s secret object
+                    type: string
+                  type:
+                    description: type of K8s secret object
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+          properties:
+            byPod:
+              items:
+                description: ByPodStatus defines the state of SecretProviderClass
+                  as seen by an individual controller
+                properties:
+                  id:
+                    description: id of the pod that wrote the status
+                    type: string
+                  namespace:
+                    description: namespace of the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-secrets-store
+  namespace: cluster-baseline-settings
+  labels:
+    app: csi-secrets-store
+    app.kubernetes.io/name: csi-secrets-store
+    app.kubernetes.io/component: csi-driver
+spec:
+  selector:
+    matchLabels:
+      app: csi-secrets-store
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store
+        app.kubernetes.io/name: csi-secrets-store
+        app.kubernetes.io/component: csi-driver
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        agentpool: npuser01
+      serviceAccountName: secrets-store-csi-driver
+      hostNetwork: true
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  [
+                    "/bin/sh",
+                    "-c",
+                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
+                  ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: secrets-store
+          image: docker.io/deislabs/secrets-store-csi:v0.0.11
+          args:
+            - "--debug=true" #TODO switch to false once it is working fine
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+            - name: providers-dir
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          imagePullPolicy: Always
+          args:
+          - --csi-address=/csi/csi.sock
+          - --probe-timeout=3s
+          - --health-port=9808
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-secrets-store/
+            type: DirectoryOrCreate
+        - name: providers-dir
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+            type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: cluster-baseline-settings
+  labels:
+    app: csi-secrets-store-provider-azure
+    app.kubernetes.io/name: csi-secrets-store-provider-azure
+    app.kubernetes.io/component: csi-provider
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-azure
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-azure
+        app.kubernetes.io/name: csi-secrets-store-provider-azure
+        app.kubernetes.io/component: csi-provider
+    spec:
+      containers:
+        - name: provider-azure-installer
+          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        agentpool: npuser01

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -889,9 +889,9 @@
             "type":"string",
             "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'aksic-to-keyvault')]"
         },
-        "aksIngressControllerUserManageIdentityPrincipalClientId":{
+        "aksIngressControllerUserManageIdentityClientId":{
             "type":"string",
-            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','appw-to-keyvault')).principalId]"
+            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','aksic-to-keyvault')).clientId]"
         }
     }
 }

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -892,6 +892,10 @@
         "aksIngressControllerUserManageIdentityClientId":{
             "type":"string",
             "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','aksic-to-keyvault')).clientId]"
+        },
+        "keyVaultName":{
+            "type":"string",
+            "value": "[variables('keyVaultName')]"
         }
     }
 }

--- a/aks/secure-baseline/cluster-stamp.json
+++ b/aks/secure-baseline/cluster-stamp.json
@@ -85,9 +85,13 @@
         "networkContributorRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7')]",
         "monitoringMetricsPublisherRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb')]",
         "acrPullRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+        "managedIdentityOperatorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830')]",
+        "virtualMachineContributorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+        "readerRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
 
         "subRgUniqueString": "[uniqueString('aks', subscription().subscriptionId, resourceGroup().id)]",
 
+        "nodeResourceGroupName": "[concat('rg-', variables('clusterName'), '-nodepools')]",
         "clusterName": "[concat('aks-', variables('subRgUniqueString'))]",
         "logAnalyticsWorkspaceName": "[concat('la-', variables('clusterName'))]",
         "containerInsightsSolutionName": "[concat('ContainerInsights(', variables('logAnalyticsWorkspaceName'),')')]",
@@ -109,12 +113,19 @@
             "location": "[parameters('location')]"
         },
         {
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "name": "aksic-to-keyvault",
+            "apiVersion": "2018-11-30",
+            "location": "[parameters('location')]"
+        },
+        {
             "type": "Microsoft.KeyVault/vaults",
             "name": "[variables('keyVaultName')]",
             "apiVersion": "2019-09-01",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'appw-to-keyvault')]"
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'appw-to-keyvault')]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'aksic-to-keyvault')]"
             ],
             "properties": {
                 "accessPolicies": [
@@ -123,6 +134,18 @@
                         "objectId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','appw-to-keyvault')).principalId]",
                         "permissions": {
                             "secrets": [
+                                "get"
+                            ]
+                        }
+                    },
+                    {
+                        "tenantId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','aksic-to-keyvault')).tenantId]",
+                        "objectId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','aksic-to-keyvault')).principalId]",
+                        "permissions": {
+                            "secrets": [
+                                "get"
+                            ],
+                            "certificates": [
                                 "get"
                             ]
                         }
@@ -444,6 +467,33 @@
             }
         },
         {
+            "type": "Microsoft.Resources/deployments",
+            "name": "EnsureClusterUserAssignedHasRbacToManageVMSS",
+            "apiVersion": "2017-05-10",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
+            ],
+            "resourceGroup": "[variables('nodeResourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "name": "[guid(resourceGroup().id)]",
+                            "apiVersion": "2018-09-01-preview",
+                            "comments": "It is required to grant the AKS cluster with Virtual Machine Contributor role permissions over the cluster infrastructure resource group to work with Managed Identities and aad-pod-identity. Otherwise MIC component fails while attempting to update MSI on VMSS cluster nodes",
+                            "properties": {
+                                "roleDefinitionId": "[variables('virtualMachineContributorRole')]",
+                                "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName')), '2020-03-01').identityProfile.kubeletidentity.objectId]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },{
             "type": "Microsoft.OperationalInsights/workspaces",
             "apiVersion": "2015-11-01-preview",
             "name": "[variables('logAnalyticsWorkspaceName')]",
@@ -682,7 +732,7 @@
                         "enabled": false
                     }
                 },
-                "nodeResourceGroup": "[concat('rg-', variables('clusterName'), '-nodepools')]",
+                "nodeResourceGroup": "[variables('nodeResourceGroupName')]",
                 "enableRBAC": true,
                 "enablePodSecurityPolicy": false,
                 "maxAgentPools": 2,
@@ -756,6 +806,34 @@
             }
         },
         {
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments",
+            "name": "[concat('aksic-to-keyvault', '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('managedIdentityOperatorRole')))]",
+            "apiVersion": "2018-09-01-preview",
+            "comments": "Grant the AKS cluster with Manage Identity Operator role permissions over the cluster resource group",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('managedIdentityOperatorRole')]",
+                "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName')), '2020-03-01').identityProfile.kubeletidentity.objectId]"
+            }
+        },
+        {
+            "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
+            "apiVersion": "2018-09-01-preview",
+            "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('readerRole')))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'aksic-to-keyvault')]"
+            ],
+            "comments": "Grant the AKS cluster ingress controller with reader role permissions over KeyVault",
+            "properties": {
+                "roleDefinitionId": "[variables('readerRole')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','aksic-to-keyvault')).principalId]",
+                "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+            }
+        },
+        {
             "type": "Microsoft.ContainerRegistry/registries/providers/diagnosticSettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(variables('defaultAcrName'), '/Microsoft.Insights/default')]",
@@ -806,6 +884,14 @@
         "agwName": {
             "type": "string",
             "value": "[variables('agwName')]"
+        },
+        "aksIngressControllerUserManageIdentityResourceId":{
+            "type":"string",
+            "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'aksic-to-keyvault')]"
+        },
+        "aksIngressControllerUserManageIdentityPrincipalClientId":{
+            "type":"string",
+            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','appw-to-keyvault')).principalId]"
         }
     }
 }

--- a/aks/workload/traefik.yaml
+++ b/aks/workload/traefik.yaml
@@ -182,6 +182,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik-ingress-ilb
     app.kubernetes.io/instance: traefik-ingress-ilb
+    aadpodidbinding: traefik-ingress-controller
 spec:
   replicas: 2
   selector:
@@ -201,6 +202,7 @@ spec:
       labels:
         app.kubernetes.io/name: traefik-ingress-ilb
         app.kubernetes.io/instance: traefik-ingress-ilb
+        aadpodidbinding: traefik-ingress-controller
     spec:
       hostNetwork: false
       serviceAccountName: traefik-ingress-controller

--- a/aks/workload/traefik.yaml
+++ b/aks/workload/traefik.yaml
@@ -263,7 +263,7 @@ spec:
           - name: config
             mountPath: /config
             readOnly: true
-          - name: ssl
+          - name: ssl-csi
             mountPath: /certs
             readOnly: true
         args:
@@ -272,9 +272,12 @@ spec:
         - name: config
           configMap:
             name: traefik-ingress-config
-        - name: ssl
-          secret:
-            secretName: bicycle-contoso-com-tls-secret
+        - name: ssl-csi
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "aks-ingress-contoso-com-tls-secret-csi-akv"
         - name: data
           emptyDir: {}
       nodeSelector:


### PR DESCRIPTION
1. aks and ingress controller access policies + rbac permissions

    the AKS-manage cluster user assigned identity needs permissions to operate and bind
    a new in-cluster ingress controller user assigned identity. This will
    allow `aad-pod-identity` read the user assigned identity (`AzureIdenity`)
    as well as (un)assign it (`AzureIdentityBinding`) to a Pod (`AzureIdentityAssigned`).

    aad-pod-identity requires this new ingress controller user assigned identity
    to be able to read the Azure KeyVault resource instance.

    In the end, the acquired access token on behalf of this new user assigned identity
    must provide the Pod with the proper claims, so it can access the secrets and
    certificates from the Azure KeyVault instances. This will require to give the
    proper access policies to the new in-cluster ingress controller.

    - create a new user manage identity for the Aks Ingress Controller named
      `aksic-to-akv`. This is the identity we want to bring and be assigned to Traefik's pods
    - [Role Assignemnt] assign the Azure built-in `Managed Identity Operator` Role permissions 
      * to: the Aks cluster user assigned identity 
      * over/scope: `aksic-to-akv`
This way AAD Pod Identity can read and (un)assign new `aksic-to-akv` user assigned identity 
    - [Role Assignemnt] assign the Azure built-in `Virtual Machine Contributor` Role permissions 
       * to: the Aks cluster user assigned identity 
       * over/scope: the Aks cluster infrastructure resource group.
These role permissions, specially `Microsoft.Compute/virtualMachineScaleSets/writer` is
      needed while updating MSI(s) on aks nodes. Pod identity is getting
      bind through the node where it is running.Without this permissions the MIC
      component fails while attempting to update MSI on VMSS cluster nodes
    - [Role Assignemnt] assign the Azure built-in `Reader` Role permissions 
       * to: `aksic-to-akv` 
        * over/scope: Azure KeyVault resource instance
    - [Access Policies] set GET policy access on AKV secrets and certs to `aksic-to-akv`
    - output new user manage identity for Aks Ingress controller as params for AzureIdentity

    For more information about the required role assigments and access
    policies for Azure Active Directory Pod Identity to work, please let's
    take a look at https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.role-assignment.md#performing-role-assignments

2. Flux to deploy:
    - aad-pod-identity
    - Kubernetes CSI driver
    - Azure KeyVault CSI Provider
3. enable aad-pod-identity for Traefik
4. add SecretProviderClass for Traefik to integrate with secret-store-csi-provider-azure
5. import certificate to AKV